### PR TITLE
adding demo containers with flux laamps and mpi

### DIFF
--- a/.github/workflows/build-matrices.yaml
+++ b/.github/workflows/build-matrices.yaml
@@ -1,0 +1,115 @@
+name: Container (Demo) Build Matrices
+
+on: 
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+  pull_request: []
+
+jobs:
+  generate:
+    name: Generate Build Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      dockerbuild_matrix: ${{ steps.dockerbuild.outputs.dockerbuild_matrix }}
+      empty_matrix: ${{ steps.dockerbuild.outputs.dockerbuild_matrix_empty }}
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+         fetch-depth: 0
+
+    - name: Generate Build Matrix
+      uses: vsoch/uptodate@main
+      id: dockerbuild
+      with: 
+        root: docker
+        parser: dockerbuild
+        flags: "--all"
+
+    - name: View and Check Build Matrix Result
+      env:
+        result: ${{ steps.dockerbuild.outputs.dockerbuild_matrix }}
+      run: |
+        echo ${result}
+        if [[ "${result}" == "[]" ]]; then
+          printf "The matrix is empty, will not trigger next workflow.\n"
+        else
+          printf "The matrix is not empty, and we should continue on to the next workflow.\n"
+        fi
+
+  build:
+    needs:
+      - generate
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        result: ${{ fromJson(needs.generate.outputs.dockerbuild_matrix) }}
+        arch: ['linux/amd64']
+
+    if: ${{ needs.generate.outputs.empty_matrix == 'false' }}
+
+    name: "Build ${{ matrix.result.container_name }} ${{ matrix.arch[0] }}" 
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v3
+    - uses: actions/setup-go@v2
+    - uses: imjasonh/setup-crane@01d26682810dcd47bfc8eb1efe791558123a9373
+
+    - name: GHCR Login
+      if: (github.event_name != 'pull_request')
+      uses: docker/login-action@v1 
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    
+   # Uncomment if need more build space   
+   # - name: Run Actions Cleaner
+   #   uses: rse-ops/actions-cleaner/ubuntu@main
+
+    - name: Pull Docker Layers
+      env:
+        container: ${{ matrix.result.container_name }}
+      run: docker pull ghcr.io/flux-framework/${container} || exit 0
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Prepare ${{ matrix.result.container_name }}
+      id: builder
+      env:
+        container: ${{ matrix.result.container_name }}
+        prefix: ${{ matrix.result.command_prefix }}
+        filename: ${{ matrix.result.filename }}
+      run: |
+        basedir=$(dirname $filename)
+        printf "Base directory is ${basedir}\n"
+        # Get relative path to PWD and generate dashed name from it
+        cd $basedir
+        echo "${prefix} -t ${container} ."
+        build_args="$(echo "${prefix#*--build-arg}")"
+        # Add build-arg for anaconda download
+        echo "dockerfile_dir=${basedir}" >> $GITHUB_ENV
+        echo "build_args=${build_args}" >> $GITHUB_ENV
+        echo "container=${container}" >> $GITHUB_ENV
+        echo "filename=${filename}" >> $GITHUB_ENV
+
+    - name: Build ${{ matrix.dockerfile[1] }}
+      uses: docker/build-push-action@v2
+      with:
+        context: ${{ env.dockerfile_dir }}
+        file: ${{ env.filename }}
+        platforms: ${{ matrix.arch[0] }}
+        push: ${{ github.event_name != 'pull_request' }}
+        build-args: |
+          ${{ env.build_args }}
+        tags: ghcr.io/flux-framework/${{ env.container }}

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,5 @@
+# Docker Container
+
+The following automated builds are provided alongside the Flux Operator:
+
+ - [demo-lammps-mpi](demo-lammps-mpi): A demo mpi container that can be used for a MiniCluster

--- a/docker/demo-lammps-mpi/Dockerfile
+++ b/docker/demo-lammps-mpi/Dockerfile
@@ -17,8 +17,8 @@ RUN apt-get update && \
     apt-get install -y fftw3-dev fftw3
 
 # install laamps
-RUN git clone --depth 1 --branch stable_29Sep2021_update2 https://github.com/lammps/lammps.git /opt/laamps && \
-    cd /opt/laamps && \
+RUN git clone --depth 1 --branch stable_29Sep2021_update2 https://github.com/lammps/lammps.git /opt/lammps && \
+    cd /opt/lammps && \
     mkdir build && \
     cd build && \
     . /etc/profile && \ 

--- a/docker/demo-lammps-mpi/Dockerfile
+++ b/docker/demo-lammps-mpi/Dockerfile
@@ -1,0 +1,31 @@
+ARG flux_sched_tag
+FROM fluxrm/flux-sched:${flux_sched_tag}
+ARG build_jobs=6
+ENV build_jobs=${build_jobs}
+
+# docker build --build-arg flux_sched_tag=focal -t ghcr.io/flux-framework/demo-mpi:focal .
+
+# Potential entrypoint:
+#    mpirun --allow-run-as-root --mca orte_launch_agent /opt/view/bin/orted --mca plm_rsh_agent rsh -x PATH -x LD_LIBRARY_PATH -np 2 --map-by socket lmp -v x 2 -v y 2 -v z 2 -in in.reaxc.hns -nocite
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# It's good to be root :)
+USER root
+WORKDIR /opt/
+RUN apt-get update && \
+    apt-get install -y fftw3-dev fftw3
+
+# install laamps
+RUN git clone --depth 1 --branch stable_29Sep2021_update2 https://github.com/lammps/lammps.git /opt/laamps && \
+    cd /opt/laamps && \
+    mkdir build && \
+    cd build && \
+    . /etc/profile && \ 
+    cmake ../cmake -D PKG_REAXFF=yes -D BUILD_MPI=yes -D PKG_OPT=yes -D FFT=FFTW3 && \
+    make -j ${build_jobs} && \
+    make install
+  
+# Target this example
+ENV PATH=/root/.local/bin:$PATH
+WORKDIR /opt/lammps/examples/reaxff/HNS

--- a/docker/demo-lammps-mpi/uptodate.yaml
+++ b/docker/demo-lammps-mpi/uptodate.yaml
@@ -1,0 +1,10 @@
+dockerbuild:
+
+  build_args:
+    flux_sched_tag:
+      key: flux-sched
+      versions:
+       - focal
+       - focal-v0.22.0
+       - focal-v0.23.0
+       - focal-v0.24.0


### PR DESCRIPTION
this set of automated builds will prepare several bases for an operator demo. The container builds are under docker, and designed so we can add any new set of subfolders and uptodate.yaml files that will result in matrix builds.

I tried the demo locally and think it worked? Haven't used laamps before!

![image](https://user-images.githubusercontent.com/814322/189031746-bfdb9368-bf64-41e6-ab1c-7770187c5b9a.png)


Signed-off-by: vsoch <vsoch@users.noreply.github.com>