### PR TITLE
testing updated container build

### DIFF
--- a/.github/workflows/build-matrices.yaml
+++ b/.github/workflows/build-matrices.yaml
@@ -1,6 +1,8 @@
 name: Container (Demo) Build Matrices
 
 on: 
+  # Enable for testing builds for a PR
+  pull_request: []
   push:
     branches:
       - main

--- a/docker/README.md
+++ b/docker/README.md
@@ -10,8 +10,10 @@ so that the install locations are consistent. This assumes that:
 
  - `/etc/flux` is used for configuration and general setup
  - `/usr/libexec/flux` has executables like flux-imp, flux-shell
- - `pdsh` is installed, which allows to (in parallel) start the cluster
  - flux-core / flux-sched with flux-security should be installed.
- 
+ - If you haven't created a flux user, one will be created for you (with a common user id 1234)
+ - Any executables that the flux user needs for your job should be on the path.
+ - The container (for now) should start with user root, and we run commands on behalf of flux.
+  
 If/when needed we can lift some of these constraints, but for now they are 
 reasonable.

--- a/docker/demo-lammps-mpi/Dockerfile
+++ b/docker/demo-lammps-mpi/Dockerfile
@@ -6,7 +6,7 @@ ENV build_jobs=${build_jobs}
 # docker build --build-arg flux_sched_tag=focal -t ghcr.io/flux-framework/demo-mpi:focal .
 
 # Potential entrypoint:
-#    mpirun --allow-run-as-root -x PATH -np 2 --map-by socket lmp -v x 2 -v y 2 -v z 2 -in in.reaxc.hns -nocite
+#    mpirun -x PATH -np 2 --map-by socket lmp -v x 2 -v y 2 -v z 2 -in in.reaxc.hns -nocite
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -25,7 +25,15 @@ RUN git clone --depth 1 --branch stable_29Sep2021_update2 https://github.com/lam
     cmake ../cmake -D PKG_REAXFF=yes -D BUILD_MPI=yes -D PKG_OPT=yes -D FFT=FFTW3 && \
     make -j ${build_jobs} && \
     make install
-  
+
+# Create a home to put the examples in, and
+# ensure lmp executable is on path for flux user
+# And anyone can interact with lammps examples
+RUN useradd -ms /bin/bash -u 1234 flux && \
+    mv /opt/lammps/examples /home/flux/examples && \
+    chown -R 1234 /home/flux/examples && \
+    cp /root/.local/bin/lmp /usr/local/bin/lmp
+    
 # Target this example
 ENV PATH=/root/.local/bin:$PATH
-WORKDIR /opt/lammps/examples/reaxff/HNS
+WORKDIR /home/flux/examples/reaxff/HNS


### PR DESCRIPTION
we need to ensure that the lmp executable is available to the flux user, and not just root (it was by default installed to root home). We also should demonstrate creating the flux user and ensuring that permissions are set so he/she/it/they has access to the files we plan to exec. These small tweaks (per my local testing) should get the whole demo running as we expect.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>