### PR TITLE
added support for image pull secrets

### DIFF
--- a/api/v1alpha1/minicluster_types.go
+++ b/api/v1alpha1/minicluster_types.go
@@ -56,6 +56,14 @@ type MiniClusterSpec struct {
 	// +optional
 	PullAlways bool `json:"pullAlways"`
 
+	// Allow the user to pull authenticated images
+	// By default no secret is selected. Setting
+	// this with the name of an already existing
+	// imagePullSecret will specify that secret
+	// in the pod spec.
+	// +optional
+	ImagePullSecrets []string `json:"imagePullSecrets"`
+
 	// Single user executable to provide to flux start
 	// +optional
 	Command string `json:"command"`

--- a/api/v1alpha1/minicluster_types.go
+++ b/api/v1alpha1/minicluster_types.go
@@ -62,7 +62,7 @@ type MiniClusterSpec struct {
 	// imagePullSecret will specify that secret
 	// in the pod spec.
 	// +optional
-	ImagePullSecrets []string `json:"imagePullSecrets"`
+	ImagePullSecret string `json:"imagePullSecret"`
 
 	// Single user executable to provide to flux start
 	// +optional

--- a/config/samples/flux-framework.org_v1alpha1_minicluster.yaml
+++ b/config/samples/flux-framework.org_v1alpha1_minicluster.yaml
@@ -19,3 +19,5 @@ spec:
   diagnostics: false
   # Deadline in seconds, if not set there is no deadline
   # deadlineSeconds: 100
+  # Name of an already created ImagePullSecret for the image specfied above
+  # imagePullSecret: flux-image-secret

--- a/controllers/flux/job.go
+++ b/controllers/flux/job.go
@@ -56,10 +56,11 @@ func (r *MiniClusterReconciler) newMiniClusterJob(cluster *api.MiniCluster) *bat
 					Labels: map[string]string{"name": cluster.Name, "namespace": cluster.Namespace, "job": cluster.Name},
 				},
 				Spec: corev1.PodSpec{
-					Subdomain:     cluster.Name,
-					Volumes:       getVolumes(cluster),
-					Containers:    containers,
-					RestartPolicy: corev1.RestartPolicyOnFailure,
+					Subdomain:        cluster.Name,
+					Volumes:          getVolumes(cluster),
+					Containers:       containers,
+					RestartPolicy:    corev1.RestartPolicyOnFailure,
+					ImagePullSecrets: getImagePullSecrets(cluster),
 				}},
 		},
 	}
@@ -92,4 +93,17 @@ func (r *MiniClusterReconciler) getMiniClusterContainers(cluster *api.MiniCluste
 		},
 	}
 	return containers
+}
+
+// Function to return list of objects references for
+// imagePullSecrets
+func getImagePullSecrets(cluster *api.MiniCluster) []corev1.LocalObjectReference {
+	var pullSecrets []corev1.LocalObjectReference
+	var pullSecret corev1.LocalObjectReference
+	for _, secretName := range cluster.Spec.ImagePullSecrets {
+		pullSecret = corev1.LocalObjectReference{Name: secretName}
+		pullSecrets = append(pullSecrets, pullSecret)
+	}
+
+	return pullSecrets
 }

--- a/controllers/flux/job.go
+++ b/controllers/flux/job.go
@@ -60,7 +60,7 @@ func (r *MiniClusterReconciler) newMiniClusterJob(cluster *api.MiniCluster) *bat
 					Volumes:          getVolumes(cluster),
 					Containers:       containers,
 					RestartPolicy:    corev1.RestartPolicyOnFailure,
-					ImagePullSecrets: getImagePullSecrets(cluster),
+					ImagePullSecrets: getImagePullSecret(cluster),
 				}},
 		},
 	}
@@ -96,14 +96,11 @@ func (r *MiniClusterReconciler) getMiniClusterContainers(cluster *api.MiniCluste
 }
 
 // Function to return list of objects references for
-// imagePullSecrets
-func getImagePullSecrets(cluster *api.MiniCluster) []corev1.LocalObjectReference {
-	var pullSecrets []corev1.LocalObjectReference
-	var pullSecret corev1.LocalObjectReference
-	for _, secretName := range cluster.Spec.ImagePullSecrets {
-		pullSecret = corev1.LocalObjectReference{Name: secretName}
-		pullSecrets = append(pullSecrets, pullSecret)
+// imagePullSecrets. Current Spec only allows for a
+// single secret to be used. 
+func getImagePullSecret(cluster *api.MiniCluster) []corev1.LocalObjectReference {
+	pullSecrets := []corev1.LocalObjectReference{
+		corev1.LocalObjectReference{Name: cluster.Spec.ImagePullSecret},
 	}
-
 	return pullSecrets
 }


### PR DESCRIPTION
This PR adds in support for imagePullSecrets. 

## Overview
To accomplish this goal, the PR adds in a new optional specification `imagePullSecrets` that accepts a list of strings. These strings represent secrets that already exist that contain the image registry credentials. This was implemented by adding the new parameter in the minicluster_types and then adding the pull secret to the podspec in the job.

One point of discussion is the list implementation. The idea here is that the podspec takes a list of imagePullSecrets because a pod can use multiple images and potentially need multiple pull secrets. In our current architecture, users can only specify a single image, so perhaps it would be simpler to reduce this parameter to just a string instead? I could go either way in this regard.

## Testing 
I tested the changes made by this PR by pushing the same image we have already used for testing into a private docker hub repo. From there, I created an ImagePullSecret in the same namespace I was working in. See https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ for details on creating image pull secrets. I tested 4 different cases, with public/private image with and without imagePullSecret. The only case that failed to pull the image was in the case of a private repo without an image pull secret. For all tests, `pullAlways` was set to `true`. 

## Example Config :
```
apiVersion: flux-framework.org/v1alpha1
kind: MiniCluster
metadata:
  name: flux-sample
  namespace: flux-operator
spec:
  # The container URI to pull (currently needs to be public)
  image: zekemorton/flux
  # The main flux command to run - the job will exit after
  command: mpirun -x PATH -np 2 --map-by socket lmp -v x 2 -v y 2 -v z 2 -in in.reaxc.hns -nocite
  # You can set the working directory if your container WORKDIR is not correct.
  workingDir: /home/flux/examples/reaxff/HNS
  # Always pull the image (if you are updating the image between runs, set to true)!
  pullAlways: true
  # Number of pods to create for MiniCluster
  size: 6
  # Diagnostics runs flux commands for diagnostics, and a final sleep command
  # That makes it easy for you to shell into the pod to look around
  diagnostics: false
  # Deadline in seconds, if not set there is no deadline
  # deadlineSeconds: 100
  imagePullSecrets:
  - regcred
  ```