### PR TITLE
final tweaks for production volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ $ cd flux-operator
 
 Ensure localDeploy is set to true in your CRD so you don't ask for a persistent volume claim!
 
+```yaml
+spec:
+# Set to true to use volume mounts instead of volume claims
+  localDeploy: true
+```
+
+And then:
+
 ```
 # Start a minikube cluster
 $ minikube start
@@ -188,7 +196,16 @@ Make your namespace for the flux-operator:
 $ kubectl create namespace flux-operator
 ```
 
-Then apply your CRD (the localDeploy can be false for an actual cluster with persistent volume claims):
+Then apply your CRD - importantly, the localDeploy needs to be false. Basically, setting to true uses a local mount,
+which obviously won't work for different instances in the cloud!
+
+```yaml
+spec:
+# Set to true to use volume mounts instead of volume claims
+  localDeploy: false
+```
+
+This means we will use peristent volume claims instead. Then do:
 
 ```bash
 $ make apply

--- a/config/samples/flux-framework.org_v1alpha1_minicluster.yaml
+++ b/config/samples/flux-framework.org_v1alpha1_minicluster.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-operator
 spec:
   # Set to true to use volume mounts instead of volume claims
-  # localDeploy: true
+  localDeploy: true
   # The container URI to pull (currently needs to be public)
   image: ghcr.io/flux-framework/demo-lammps-mpi:flux-sched-focal-v0.22.0
   # The main flux command to run - the job will exit after

--- a/controllers/flux/minicluster.go
+++ b/controllers/flux/minicluster.go
@@ -53,15 +53,18 @@ func (r *MiniClusterReconciler) ensureMiniCluster(ctx context.Context, cluster *
 	}
 
 	// A local host (developer machine) does not support provisioning, so for the meantime we use a
-	// persistent volume instead
+	// persistent volume instead (running on same host)
 	if cluster.Spec.LocalDeploy {
+		r.log.Info("MiniCluster", "localDeploy", "true (persistent volume in /tmp)")
 		_, result, err = r.getPersistentVolume(ctx, cluster, cluster.Name+curveVolumeSuffix)
 		if err != nil {
 			return result, err
 		}
 
 		// Otherwise we can ask for a persistent volume claim
+		// (not running on the same host)
 	} else {
+		r.log.Info("MiniCluster", "localDeploy", "false (persistent volume claim)")
 		_, result, err = r.getPersistentVolumeClaim(ctx, cluster, cluster.Name+curveVolumeSuffix)
 		if err != nil {
 			return result, err
@@ -389,7 +392,7 @@ func (r *MiniClusterReconciler) createPersistentVolumeClaim(cluster *api.MiniClu
 		TypeMeta:   metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{Name: configName, Namespace: cluster.Namespace},
 		Spec: corev1.PersistentVolumeClaimSpec{
-			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 
 			// No idea how much to ask for here! I made it up.
 			Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{

--- a/controllers/flux/templates/wait.sh
+++ b/controllers/flux/templates/wait.sh
@@ -11,14 +11,15 @@ asFlux="sudo -u flux"
 # Broker Options: important!
 # The local-uri setting places the unix domain socket in rundir 
 #   if FLUX_URI is not set, tools know where to connect.
+#   -Slog-stderr-level= can be set to 7 for larger debug level
+#   or exposed as a variable
 brokerOptions="-Scron.directory=/etc/flux/system/cron.d \
   -Stbon.fanout=256 \
   -Srundir=/run/flux \
   -Sstatedir=${STATE_DIRECTORY:-/var/lib/flux} \
   -Slocal-uri=local:///run/flux/local \
   -Slog-stderr-level=6 \
-  -Slog-stderr-mode=local \
-  -Sbroker.exit-norestart=42"
+  -Slog-stderr-mode=local"
 
 # quorum settings influence how the instance treats missing ranks
 #   by default all ranks must be online before work is run, but


### PR DESCRIPTION
we need to be able to switch between a persistent volume claim (for production) and a local mount (for development). This example I tested and it works for local and eks. I'm going to try and PR to @milroy private repo with complete instructions for eks.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>