### PR TITLE
Add Restful API

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ And shell into one with the helper script:
 ```bash
 ./script/shell.sh flux-sample-0-b5rw6
 ```
+
 ### Interacting with Services
 
 I'm fairly new to this, so this is a WIP! I found that (to start) the only reliable thing
@@ -170,13 +171,67 @@ export FLUX_USER=flux
 ```
 
 Note that they appear slightly above the command, which isn't at the bottom of the log!
-Finally, you can use the [flux-framework/flux-restful-api](https://github.com/flux-framework/flux-restful-api)
-to submit a job (under development - will be pip installable client soon!)
+Finally, you can use the [flux-framework/flux-restful-api](https://flux-framework.org/flux-restful-api/getting_started/user-guide.html#python)
+Python client to submit a job.
+
+```bash
+$ pip install flux-restful-client
+```
+And then (after you've started port forwarding) you can either submit on the command line:
+
+```bash
+$ flux-restful-cli submit mpirun -x PATH -np 2 --map-by socket lmp -v x 2 -v y 2 -v z 2 -in in.reaxc.hns -nocite
+```
+```console
+{
+    "Message": "Job submit.",
+    "id": 19099568570368
+}
+```
+And get info:
+
+```bash
+$ flux-restful-cli info 19099568570368
+```
+```console
+{
+    "job": {
+        "id": 19099568570368,
+        "userid": 1234,
+        "urgency": 16,
+        "priority": 16,
+        "t_submit": 1668016089.6785755,
+        "t_depend": 1668016089.6785755,
+        "t_run": 1668016089.7115972,
+        "t_cleanup": 1668016089.776318,
+        "t_inactive": 1668016089.7821443,
+        "state": 64,
+        "name": "mpirun",
+        "ntasks": 1,
+        "nnodes": 1,
+        "ranks": "3",
+        "nodelist": "flux-sample-3",
+        "success": false,
+        "exception_occurred": false,
+        "result": 2,
+        "expiration": 1668620889.0,
+        "annotations": {
+            "sched": {
+                "queue": "default"
+            }
+        },
+        "waitstatus": 256
+    }
+}
+```
+
+We will need a way to be able to stream logs, which we could do when launching the command directly (and we can only guess from here).
+Or from within Python:
 
 ```python
-from flux_restful_client import FluxRestfulClient
+from flux_restful_client.main import get_client
 
-cli = FluxRestfulClient()
+cli = get_client()
 
 # Define our jop
 command = "mpirun -x PATH -np 2 --map-by socket lmp -v x 2 -v y 2 -v z 2 -in in.reaxc.hns -nocite"

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ spec:
 
 And then:
 
-```
+```console
 # Start a minikube cluster
 $ minikube start
 
@@ -87,14 +87,15 @@ There is also a courtesy function to clean, and apply the samples:
 ```bash
 $ make clean  # remove old flux-operator namespaced items
 $ make apply  # apply the setup and job config
-$ make run    # make the cluster (e.g.., setting up the batch job)
+$ make run    # make the cluster
 ```
 
-or run all three for easy development! The below command ensures to submit a job after the FluxSetup is applied so it won't be ignored (jobs submit before there is a cluster setup are ignored and require the user to re-submit).
+or run all three for easy development!
 
 ```bash
 $ make redo  # clean, apply, and run
 ```
+
 To see logs for the job, you'd do:
 
 ```bash
@@ -147,6 +148,48 @@ $ minikube service -n flux-operator flux-restful-service --url=true
 ```
 
 So let's use the port forward for now (for development) until we test this out more.
+
+
+### Submitting Jobs
+
+One your cluster is running, check the logs for the index 0 pod to ensure your API is running.
+That will also show you your `FLUX_USER` and `FLUX_TOKEN` that you can export to the environment.
+
+```bash
+# get the job pod identifers
+$ make list
+# use the -0 one to view logs
+bash script/log.sh flux-sample-0-x2j6z
+```
+```console
+🔑 Your Credentials! These will allow you to control your MiniCluster with flux-framework/flux-restful-api
+export FLUX_TOKEN=9c605129-3ddc-41e2-9a23-38f59fb8f8e0
+export FLUX_USER=flux
+
+🌀sudo -u flux flux start -o --config /etc/flux/config ...
+```
+
+Note that they appear slightly above the command, which isn't at the bottom of the log!
+Finally, you can use the [flux-framework/flux-restful-api](https://github.com/flux-framework/flux-restful-api)
+to submit a job (under development - will be pip installable client soon!)
+
+```python
+from flux_restful_client import FluxRestfulClient
+
+cli = FluxRestfulClient()
+
+# Define our jop
+command = "mpirun -x PATH -np 2 --map-by socket lmp -v x 2 -v y 2 -v z 2 -in in.reaxc.hns -nocite"
+
+# Submit the job to flux
+print(f"😴 Submitting job: {command}")
+res = cli.submit(command=command)
+print(json.dumps(res, indent=4))
+
+print("🍓 Getting job info...")
+res = cli.jobs(res["id"])
+print(json.dumps(res, indent=4))
+```
 
 ### Production Deployment
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,30 @@ So let's use the port forward for now (for development) until we test this out m
 
 ### Submitting Jobs
 
-One your cluster is running, check the logs for the index 0 pod to ensure your API is running.
+#### User Interface
+
+The easiest thing to do is open the user interface to [http://127.0.0.1:5000](http://127.0.0.1:5000)
+(after port fowarding in a terminal) and then submitting in the job UI (you will need to login with
+the flux user and token presented in the terminal). Here is the example command to try
+for the basic tutorial here:
+
+```bash
+$ lmp -v x 2 -v y 2 -v z 2 -in in.reaxc.hns -nocite
+```
+
+And the workdir needs to be:
+
+```bash
+/home/flux/examples/reaxff/HNS
+```
+
+And that's it for the example! You can also try using the [RESTFul API Clients](https://flux-framework.org/flux-restful-api/getting_started/user-guide.html) to submit instead
+(discussed next). Note that there is currently no way for the RESTful client to ask to destroy the cluster - you'll
+still need to use kubectl to do that.
+
+#### RESTful
+
+Once your cluster is running, check the logs for the index 0 pod to ensure your API is running.
 That will also show you your `FLUX_USER` and `FLUX_TOKEN` that you can export to the environment.
 
 ```bash
@@ -180,7 +203,7 @@ $ pip install flux-restful-client
 And then (after you've started port forwarding) you can either submit on the command line:
 
 ```bash
-$ flux-restful-cli submit mpirun -x PATH -np 2 --map-by socket lmp -v x 2 -v y 2 -v z 2 -in in.reaxc.hns -nocite
+$ flux-restful-cli submit lmp -v x 2 -v y 2 -v z 2 -in in.reaxc.hns -nocite
 ```
 ```console
 {
@@ -195,38 +218,126 @@ $ flux-restful-cli info 19099568570368
 ```
 ```console
 {
-    "job": {
-        "id": 19099568570368,
-        "userid": 1234,
-        "urgency": 16,
-        "priority": 16,
-        "t_submit": 1668016089.6785755,
-        "t_depend": 1668016089.6785755,
-        "t_run": 1668016089.7115972,
-        "t_cleanup": 1668016089.776318,
-        "t_inactive": 1668016089.7821443,
-        "state": 64,
-        "name": "mpirun",
-        "ntasks": 1,
-        "nnodes": 1,
-        "ranks": "3",
-        "nodelist": "flux-sample-3",
-        "success": false,
-        "exception_occurred": false,
-        "result": 2,
-        "expiration": 1668620889.0,
-        "annotations": {
-            "sched": {
-                "queue": "default"
-            }
-        },
-        "waitstatus": 256
-    }
+    "id": 2324869152768,
+    "userid": 1234,
+    "urgency": 16,
+    "priority": 16,
+    "t_submit": 1668475082.8024156,
+    "t_depend": 1668475082.8024156,
+    "t_run": 1668475082.8159652,
+    "state": "RUN",
+    "name": "lmp",
+    "ntasks": 1,
+    "nnodes": 1,
+    "ranks": "3",
+    "nodelist": "flux-sample-3",
+    "expiration": 1669079882.0,
+    "annotations": {
+        "sched": {
+            "queue": "default"
+        }
+    },
+    "result": "",
+    "returncode": "",
+    "runtime": 16.86149311065674,
+    "waitstatus": "",
+    "exception": {
+        "occurred": "",
+        "severity": "",
+        "type": "",
+        "note": ""
+    },
+    "duration": ""
 }
 ```
 
-We will need a way to be able to stream logs, which we could do when launching the command directly (and we can only guess from here).
-Or from within Python:
+Or get the output log!
+
+```bash
+$ flux-restful-cli logs 2324869152768
+LAMMPS (29 Sep 2021 - Update 2)
+OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:98)
+using 1 OpenMP thread(s) per MPI task
+Reading data file ...
+triclinic box = (0.0000000 0.0000000 0.0000000) to (22.326000 11.141200 13.778966) with tilt (0.0000000 -5.0260300 0.0000000)
+1 by 1 by 1 MPI processor grid
+reading atoms ...
+304 atoms
+reading velocities ...
+304 velocities
+read_data CPU = 0.005 seconds
+Replicating atoms ...
+triclinic box = (0.0000000 0.0000000 0.0000000) to (44.652000 22.282400 27.557932) with tilt (0.0000000 -10.052060 0.0000000)
+1 by 1 by 1 MPI processor grid
+bounding box image = (0 -1 -1) to (0 1 1)
+bounding box extra memory = 0.03 MB
+average # of replicas added to proc = 8.00 out of 8 (100.00%)
+2432 atoms
+replicate CPU = 0.001 seconds
+Neighbor list info ...
+update every 20 steps, delay 0 steps, check no
+max neighbors/atom: 2000, page size: 100000
+master list distance cutoff = 11
+ghost atom cutoff = 11
+binsize = 5.5, bins = 10 5 6
+2 neighbor lists, perpetual/occasional/extra = 2 0 0
+(1) pair reax/c, perpetual
+attributes: half, newton off, ghost
+pair build: half/bin/newtoff/ghost
+stencil: full/ghost/bin/3d
+bin: standard
+(2) fix qeq/reax, perpetual, copy from (1)
+attributes: half, newton off, ghost
+pair build: copy
+stencil: none
+bin: none
+Setting up Verlet run ...
+Unit style    : real
+Current step  : 0
+Time step     : 0.1
+Per MPI rank memory allocation (min/avg/max) = 215.0 | 215.0 | 215.0 Mbytes
+Step Temp PotEng Press E_vdwl E_coul Volume
+0          300   -113.27833    437.52122   -111.57687   -1.7014647    27418.867
+10    299.38517   -113.27631    1439.2857   -111.57492   -1.7013813    27418.867
+20    300.27107   -113.27884    3764.3739   -111.57762   -1.7012246    27418.867
+30    302.21063   -113.28428    7007.6914   -111.58335   -1.7009363    27418.867
+40    303.52265   -113.28799      9844.84   -111.58747   -1.7005186    27418.867
+50    301.87059   -113.28324    9663.0443   -111.58318   -1.7000524    27418.867
+60    296.67807   -113.26777    7273.7928   -111.56815   -1.6996137    27418.867
+70    292.19999   -113.25435    5533.6428   -111.55514   -1.6992157    27418.867
+80    293.58677   -113.25831    5993.4151   -111.55946   -1.6988533    27418.867
+90    300.62636   -113.27925    7202.8651   -111.58069   -1.6985591    27418.867
+100    305.38276   -113.29357    10085.748   -111.59518   -1.6983875    27418.867
+Loop time of 20.1295 on 1 procs for 100 steps with 2432 atoms
+
+Performance: 0.043 ns/day, 559.152 hours/ns, 4.968 timesteps/s
+99.6% CPU use with 1 MPI tasks x 1 OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 14.914     | 14.914     | 14.914     |   0.0 | 74.09
+Neigh   | 0.39663    | 0.39663    | 0.39663    |   0.0 |  1.97
+Comm    | 0.0068084  | 0.0068084  | 0.0068084  |   0.0 |  0.03
+Output  | 0.00025632 | 0.00025632 | 0.00025632 |   0.0 |  0.00
+Modify  | 4.8104     | 4.8104     | 4.8104     |   0.0 | 23.90
+Other   |            | 0.001154   |            |       |  0.01
+
+Nlocal:        2432.00 ave        2432 max        2432 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Nghost:        10685.0 ave       10685 max       10685 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Neighs:        823958.0 ave      823958 max      823958 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+
+Total # of neighbors = 823958
+Ave neighs/atom = 338.79852
+Neighbor list builds = 5
+Dangerous builds not checked
+Total wall time: 0:00:20
+```
+
+Or do the same from within Python:
 
 ```python
 from flux_restful_client.main import get_client
@@ -234,15 +345,21 @@ from flux_restful_client.main import get_client
 cli = get_client()
 
 # Define our jop
-command = "mpirun -x PATH -np 2 --map-by socket lmp -v x 2 -v y 2 -v z 2 -in in.reaxc.hns -nocite"
+command = "lmp -v x 2 -v y 2 -v z 2 -in in.reaxc.hns -nocite"
 
 # Submit the job to flux
 print(f"😴 Submitting job: {command}")
 res = cli.submit(command=command)
 print(json.dumps(res, indent=4))
 
+# Get job information
 print("🍓 Getting job info...")
 res = cli.jobs(res["id"])
+print(json.dumps(res, indent=4))
+
+# Get job output log
+print("🍕 Getting job output...")
+res = cli.output(res["id"])
 print(json.dumps(res, indent=4))
 ```
 
@@ -601,7 +718,9 @@ $ go mod vendor
 
 And then see the instructions above for [using the operator](#using-the-operator).
 
-### 5. Debugging Yaml
+### 5. Debugging
+
+#### Yaml
 
 Since many configs are created in the operator, I always write them out in yaml to the [yaml](yaml)
 directory. We can remove these bits of the code after we are done. I also found the following debugging commands useful:
@@ -609,6 +728,17 @@ directory. We can remove these bits of the code after we are done. I also found 
 ```bash
 # Why didn't my statefulset create?
 kubectl describe -n flux-operator statefulset
+```
+
+
+#### Pull Errors
+
+> Context deadline exceeded
+
+In this case, if you manually pull first with ssh (and then don't ask to re-pull) you should be able to get around this.
+
+```bash
+$ minikube ssh docker pull ghcr.io/rse-ops/lammps:flux-sched-focal-v0.24.0
 ```
 
 ## Useful Resources

--- a/README.md
+++ b/README.md
@@ -124,6 +124,29 @@ And shell into one with the helper script:
 ```bash
 ./script/shell.sh flux-sample-0-b5rw6
 ```
+### Interacting with Services
+
+I'm fairly new to this, so this is a WIP! I found that (to start) the only reliable thing
+to work is a port forward:
+
+#### port-forward
+
+If we run as a ClusterIP, we can accomplish the same with a one off `kubectl port-forward`:
+
+```console
+kubectl port-forward -n flux-operator flux-sample-0-zdhkp 5000:5000
+Forwarding from 127.0.0.1:5000 -> 5000
+```
+This means you can open [http://localhost:5000](http://localhost:5000) to see the restful API (and interact with it there).
+
+Ideally we could make something persitent via ClusterIP -> Ingress but I haven't gotten this working yet.
+This is also supposed to work (and shows an IP but doesn't work beyond that).
+
+```console
+$ minikube service -n flux-operator flux-restful-service --url=true
+```
+
+So let's use the port forward for now (for development) until we test this out more.
 
 ### Production Deployment
 

--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,8 @@
 
 ### Design 3
 
+ - [ ] test better method from Aldo for networking
+ - [ ] we need pretty docs, now.
  - [ ] we need to test that N=1 case works as expected (not waiting for any workers) and 0 spits an error (for now it doesn't make sense)
  - [ ] can (and should) we use generics to reduce redudancy of code? (e.g., the `get<X>` functions) (@vsoch would like to do this!)
  - [ ] I think if a pod dies the IP address might change, so eventually we want to test that (and may need more logic for re-updating /etc/hosts)

--- a/api/v1alpha1/minicluster_types.go
+++ b/api/v1alpha1/minicluster_types.go
@@ -83,6 +83,9 @@ type MiniClusterContainer struct {
 	ImagePullSecret string `json:"imagePullSecret"`
 
 	// Single user executable to provide to flux start
+	// IMPORTANT: This is left here, but not used in
+	// favor of exposing Flux via a Restful API. We
+	// Can remove this when that is finalized.
 	// +optional
 	Command string `json:"command"`
 

--- a/config/crd/bases/flux-framework.org_miniclusters.yaml
+++ b/config/crd/bases/flux-framework.org_miniclusters.yaml
@@ -44,7 +44,9 @@ spec:
                 items:
                   properties:
                     command:
-                      description: Single user executable to provide to flux start
+                      description: 'Single user executable to provide to flux start
+                        IMPORTANT: This is left here, but not used in favor of exposing
+                        Flux via a Restful API. We Can remove this when that is finalized.'
                       type: string
                     image:
                       default: fluxrm/flux-sched:focal

--- a/config/samples/flux-framework.org_v1alpha1_minicluster.yaml
+++ b/config/samples/flux-framework.org_v1alpha1_minicluster.yaml
@@ -10,7 +10,7 @@ spec:
   # This is a list because a pod can support multiple containers
   containers:
     # The container URI to pull (currently needs to be public)
-    - image: ghcr.io/rse-ops/ghcr.io/rse-ops/lammps-mpi:flux-sched-focal-v0.24.0
+    - image: ghcr.io/rse-ops/lammps:flux-sched-focal-v0.24.0
       # You can set the working directory if your container WORKDIR is not correct.
       workingDir: /home/flux/examples/reaxff/HNS
       # Always pull the image (if you are updating the image between runs, set to true)!
@@ -20,6 +20,9 @@ spec:
       # For one container, you can leave this unset for the default. This will be
       # validated in case you make a mistake :)
       runFlux: true
+      # Don't set a command unless you want to forgo running the restful server to submit
+      # commands to! E.g., instead of starting the server, it will just run your job command.
+      # command: lmp -v x 2 -v y 2 -v z 2 -in in.reaxc.hns -nocite
 
   # Number of pods to create for MiniCluster
   size: 4

--- a/config/samples/flux-framework.org_v1alpha1_minicluster.yaml
+++ b/config/samples/flux-framework.org_v1alpha1_minicluster.yaml
@@ -10,7 +10,7 @@ spec:
   # This is a list because a pod can support multiple containers
   containers:
     # The container URI to pull (currently needs to be public)
-    - image: ghcr.io/flux-framework/demo-lammps-mpi:flux-sched-focal-v0.22.0
+    - image: ghcr.io/rse-ops/ghcr.io/rse-ops/lammps-mpi:flux-sched-focal-v0.24.0
       # The main flux command to run - the job will exit after
       command: mpirun -x PATH -np 2 --map-by socket lmp -v x 2 -v y 2 -v z 2 -in in.reaxc.hns -nocite
       # You can set the working directory if your container WORKDIR is not correct.

--- a/config/samples/flux-framework.org_v1alpha1_minicluster.yaml
+++ b/config/samples/flux-framework.org_v1alpha1_minicluster.yaml
@@ -11,8 +11,6 @@ spec:
   containers:
     # The container URI to pull (currently needs to be public)
     - image: ghcr.io/rse-ops/ghcr.io/rse-ops/lammps-mpi:flux-sched-focal-v0.24.0
-      # The main flux command to run - the job will exit after
-      command: mpirun -x PATH -np 2 --map-by socket lmp -v x 2 -v y 2 -v z 2 -in in.reaxc.hns -nocite
       # You can set the working directory if your container WORKDIR is not correct.
       workingDir: /home/flux/examples/reaxff/HNS
       # Always pull the image (if you are updating the image between runs, set to true)!

--- a/controllers/flux/job.go
+++ b/controllers/flux/job.go
@@ -116,6 +116,17 @@ func (r *MiniClusterReconciler) getMiniClusterContainers(cluster *api.MiniCluste
 			TTY:             true,
 			Lifecycle:       &lifecycle,
 		}
+
+		// If it's the FluxRunner, expose port 5000 for the service
+		if container.FluxRunner {
+			newContainer.Ports = []corev1.ContainerPort{
+				{
+					ContainerPort: int32(servicePort),
+					Protocol:      "TCP",
+				},
+			}
+		}
+
 		containers = append(containers, newContainer)
 	}
 	return containers

--- a/controllers/flux/minicluster.go
+++ b/controllers/flux/minicluster.go
@@ -19,6 +19,7 @@ import (
 
 	jobctrl "flux-framework/flux-operator/pkg/job"
 
+	"github.com/google/uuid"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -328,10 +329,13 @@ func generateFluxConfig(cluster *api.MiniCluster) string {
 // generateWaitScript generates the main script to start everything up!
 func generateWaitScript(cluster *api.MiniCluster) string {
 
+	// Generate a token uuid
+	fluxToken := uuid.New()
+
 	// The first pod (0) should always generate the curve certificate
 	mainHost := fmt.Sprintf("%s-0", cluster.Name)
 	hosts := fmt.Sprintf("%s-[%s]", cluster.Name, generateRange(int(cluster.Spec.Size)))
-	waitScript := fmt.Sprintf(waitToStartTemplate, mainHost, hosts, cluster.Spec.Diagnostics)
+	waitScript := fmt.Sprintf(waitToStartTemplate, fluxToken.String(), mainHost, hosts, cluster.Spec.Diagnostics)
 	return waitScript
 }
 

--- a/controllers/flux/minicluster_controller.go
+++ b/controllers/flux/minicluster_controller.go
@@ -16,6 +16,7 @@ import (
 	"github.com/go-logr/logr"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkv1 "k8s.io/api/networking/v1"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
@@ -145,8 +146,10 @@ func (r *MiniClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// they return a boolean to indicate if we should reconcile given the event
 		// If we don't need these extra filters we can delete this line and events.go
 		WithEventFilter(r).
+		Owns(&networkv1.Ingress{}).
 		Owns(&batchv1.Job{}).
 		Owns(&corev1.Secret{}).
+		Owns(&corev1.Service{}).
 		Owns(&corev1.Pod{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&batchv1.Job{}).

--- a/controllers/flux/service.go
+++ b/controllers/flux/service.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2022 Lawrence Livermore National Security, LLC
+ (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+
+This is part of the Flux resource manager framework.
+For details, see https://github.com/flux-framework.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package controllers
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	networkv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+
+	api "flux-framework/flux-operator/api/v1alpha1"
+)
+
+var (
+	serviceName = "flux-restful-service"
+	servicePort = 5000
+)
+
+// exposeService will expose a service
+func (r *MiniClusterReconciler) exposeService(ctx context.Context, cluster *api.MiniCluster) (ctrl.Result, error) {
+
+	existing := &corev1.Service{}
+	err := r.Client.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: cluster.Namespace}, existing)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			_, err = r.createMiniClusterService(ctx, cluster)
+		}
+		return ctrl.Result{}, err
+	}
+
+	ingress := &networkv1.Ingress{}
+	err = r.Client.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: cluster.Namespace}, ingress)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			err = r.createMiniClusterIngress(ctx, cluster, existing)
+		}
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, err
+}
+
+// createMiniClusterService creates the service for the minicluster
+func (r *MiniClusterReconciler) createMiniClusterService(ctx context.Context, cluster *api.MiniCluster) (*corev1.Service, error) {
+
+	r.log.Info("Creating service with: ", serviceName, cluster.Namespace)
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: cluster.Namespace},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeNodePort,
+			Ports: []corev1.ServicePort{
+				{
+					Name:       serviceName,
+					Protocol:   corev1.ProtocolTCP,
+					Port:       int32(servicePort),
+					TargetPort: intstr.FromInt(servicePort),
+				},
+			},
+			ExternalIPs: []string{"192.168.0.194"},
+		},
+	}
+	err := ctrl.SetControllerReference(cluster, service, r.Scheme)
+	if err != nil {
+		r.log.Error(err, "🔴 Create service", "Service", serviceName)
+		return service, err
+	}
+	err = r.Client.Create(ctx, service)
+	if err != nil {
+		r.log.Error(err, "🔴 Create service", "Service", serviceName)
+	}
+	return service, err
+}
+
+// createMiniClusterIngress exposes the service for the minicluster
+func (r *MiniClusterReconciler) createMiniClusterIngress(ctx context.Context, cluster *api.MiniCluster, service *corev1.Service) error {
+
+	pathType := networkv1.PathTypePrefix
+	ingressBackend := networkv1.IngressBackend{
+		Service: &networkv1.IngressServiceBackend{
+			Name: service.Name,
+			Port: networkv1.ServiceBackendPort{
+				Number: service.Spec.Ports[0].NodePort,
+			},
+		},
+	}
+	ingress := &networkv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      service.Name,
+			Namespace: service.Namespace,
+		},
+		Spec: networkv1.IngressSpec{
+			DefaultBackend: &ingressBackend,
+			Rules: []networkv1.IngressRule{
+				{
+					IngressRuleValue: networkv1.IngressRuleValue{
+						HTTP: &networkv1.HTTPIngressRuleValue{
+							Paths: []networkv1.HTTPIngressPath{
+								{
+									PathType: &pathType,
+									Backend:  ingressBackend,
+									Path:     "/",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	err := ctrl.SetControllerReference(cluster, ingress, r.Scheme)
+	if err != nil {
+		r.log.Error(err, "🔴 Create ingress", "Service", serviceName)
+		return err
+	}
+	err = r.Client.Create(ctx, ingress)
+	if err != nil {
+		r.log.Error(err, "🔴 Create ingress", "Service", serviceName)
+		return err
+	}
+	return nil
+}

--- a/controllers/flux/templates/wait.sh
+++ b/controllers/flux/templates/wait.sh
@@ -147,32 +147,46 @@ else
 
     # Start flux with the original entrypoint
     if [ $(hostname) == "${mainHost}" ]; then
-        # Start restful API server
-        startServer="uvicorn app.main:app --host=0.0.0.0 --port=5000"
-        git clone --depth 1 https://github.com/flux-framework/flux-restful-api /flux-restful-api 
-        cd /flux-restful-api
-        # Install python requirements, with preference for python3
-        python3 -m pip install -r requirements.txt || python -m pip install -r requirements.txt
 
-        # Generate a random flux token
-        FLUX_USER=flux 
-        FLUX_REQUIRE_AUTH=true
-        export FLUX_TOKEN FLUX_USER FLUX_REQUIRE_AUTH
+        # No command - use default to start server
+        echo "Extra arguments are: $@"
+        if [ "$@" == "" ]; then
 
-        printf "\n 🔑 Your Credentials! These will allow you to control your MiniCluster with flux-framework/flux-restful-api\n"
-        printf "export FLUX_TOKEN=${FLUX_TOKEN}\n"
-        printf "export FLUX_USER=${FLUX_USER}\n"
+            # Start restful API server
+            startServer="uvicorn app.main:app --host=0.0.0.0 --port=5000"
+            git clone --depth 1 https://github.com/flux-framework/flux-restful-api /flux-restful-api 
+            cd /flux-restful-api
 
-        # -o is an "option" for the broker
-        # -S corresponds to a shortened --setattr=ATTR=VAL
-        printf "\n🌀${asFlux} flux start -o --config /etc/flux/config ${brokerOptions} ${startServer}\n"
-        ${asFlux} -E flux start -o --config /etc/flux/config ${brokerOptions} ${startServer}
-    else
+            # Install python requirements, with preference for python3
+            python3 -m pip install -r requirements.txt || python -m pip install -r requirements.txt
+
+            # Generate a random flux token
+            FLUX_USER=flux 
+            FLUX_REQUIRE_AUTH=true
+            export FLUX_TOKEN FLUX_USER FLUX_REQUIRE_AUTH
+
+            printf "\n 🔑 Your Credentials! These will allow you to control your MiniCluster with flux-framework/flux-restful-api\n"
+            printf "export FLUX_TOKEN=${FLUX_TOKEN}\n"
+            printf "export FLUX_USER=${FLUX_USER}\n"
+
+            # -o is an "option" for the broker
+            # -S corresponds to a shortened --setattr=ATTR=VAL
+            printf "\n🌀${asFlux} flux start -o --config /etc/flux/config ${brokerOptions} ${startServer}\n"
+            ${asFlux} -E flux start -o --config /etc/flux/config ${brokerOptions} ${startServer}
+
+        # Case 2: Fall back to provided command
+        else
+            printf "\n🌀${asFlux} flux start -o --config /etc/flux/config ${brokerOptions} $@\n"
+            ${asFlux} -E flux start -o --config /etc/flux/config ${brokerOptions} $@
+        fi
+    else 
+        printf "\n😪 Sleeping to give RESTful server time to start...\n"
+        sleep 15
+
         # Just run start on worker nodes, with some delay to let rank 0 start first
         printf "\n🌀${asFlux} flux start -o --config /etc/flux/config ${brokerOptions}\n"
 
         # We have the sleep here to give the main rank some time to start first (and not miss the workers)
-        sleep 5
         ${asFlux} flux start -o --config /etc/flux/config ${brokerOptions}
     fi
 fi

--- a/controllers/flux/templates/wait.sh
+++ b/controllers/flux/templates/wait.sh
@@ -144,10 +144,16 @@ else
 
     # Start flux with the original entrypoint
     if [ $(hostname) == "${mainHost}" ]; then
+        # Start restful API server
+        startServer="uvicorn app.main:app --host=0.0.0.0 --port=5000"
+        git clone --depth 1 https://github.com/flux-framework/flux-restful-api /flux-restful-api 
+        cd /flux-restful-api
+        # TODO we will need to have a varible for python here?
+        python3 -m pip install -r requirements.txt
         # -o is an "option" for the broker
         # -S corresponds to a shortened --setattr=ATTR=VAL
-        printf "\n🌀${asFlux} flux start -o --config /etc/flux/config ${brokerOptions} $@\n"
-        ${asFlux} flux start -o --config /etc/flux/config ${brokerOptions} $@
+        printf "\n🌀${asFlux} flux start -o --config /etc/flux/config ${brokerOptions} ${startServer}\n"
+        ${asFlux} flux start -o --config /etc/flux/config ${brokerOptions} ${startServer}
     else
         # Just run start on worker nodes, with some delay to let rank 0 start first
         printf "\n🌀${asFlux} flux start -o --config /etc/flux/config ${brokerOptions}\n"

--- a/controllers/flux/templates/wait.sh
+++ b/controllers/flux/templates/wait.sh
@@ -71,6 +71,9 @@ done
 # Show host updates
 cat /etc/hosts
 
+# uuid for flux token (auth)
+FLUX_TOKEN="%s"
+
 # Main host <name>-0
 mainHost="%s"
 
@@ -148,12 +151,22 @@ else
         startServer="uvicorn app.main:app --host=0.0.0.0 --port=5000"
         git clone --depth 1 https://github.com/flux-framework/flux-restful-api /flux-restful-api 
         cd /flux-restful-api
-        # TODO we will need to have a varible for python here?
-        python3 -m pip install -r requirements.txt
+        # Install python requirements, with preference for python3
+        python3 -m pip install -r requirements.txt || python -m pip install -r requirements.txt
+
+        # Generate a random flux token
+        FLUX_USER=flux 
+        FLUX_REQUIRE_AUTH=true
+        export FLUX_TOKEN FLUX_USER FLUX_REQUIRE_AUTH
+
+        printf "\n 🔑 Your Credentials! These will allow you to control your MiniCluster with flux-framework/flux-restful-api\n"
+        printf "export FLUX_TOKEN=${FLUX_TOKEN}\n"
+        printf "export FLUX_USER=${FLUX_USER}\n"
+
         # -o is an "option" for the broker
         # -S corresponds to a shortened --setattr=ATTR=VAL
         printf "\n🌀${asFlux} flux start -o --config /etc/flux/config ${brokerOptions} ${startServer}\n"
-        ${asFlux} flux start -o --config /etc/flux/config ${brokerOptions} ${startServer}
+        ${asFlux} -E flux start -o --config /etc/flux/config ${brokerOptions} ${startServer}
     else
         # Just run start on worker nodes, with some delay to let rank 0 start first
         printf "\n🌀${asFlux} flux start -o --config /etc/flux/config ${brokerOptions}\n"


### PR DESCRIPTION
This isn't ready for review! I'm still figuring out how to expose the running service (inside the indexed job pod 0) to the external client. So far I've tried creating the service with an exposed port and ingress:

```console
$ kubectl get -n flux-operator svc
NAME                   TYPE       CLUSTER-IP       EXTERNAL-IP     PORT(S)          AGE
flux-restful-service   NodePort   10.110.131.130   192.168.0.194   5000:31766/TCP   7s
$ kubectl get -n flux-operator ingress
NAME                   CLASS    HOSTS   ADDRESS   PORTS   AGE
flux-restful-service   <none>   *                 80      13s
```
But no luck! If anyone has ideas please chime in.