### PR TITLE
diagnostics should be on level of container

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,11 +1,8 @@
 # TODO
 
-- diagnostics should be on the level of the container
-- add conveyorlc test (with new container)
-- interface still needs debugging for 2+ processes
-
 ### Design 3
 
+ - [ ] interface still needs debugging for 2+ processes
  - [ ] can (and should) we use generics to reduce redudancy of code? (e.g., the `get<X>` functions) (@vsoch would like to do this!)
  - [ ] I think if a pod dies the IP address might change, so eventually we want to test that (and may need more logic for re-updating /etc/hosts)
  - [ ] Events: deletion should clean up, and update should not be allowed (given rank 0 started)
@@ -18,6 +15,7 @@
 
 #### Completed
 
+ - [x] diagnostics should be on the level of the container
  - [x] the spec needs to support a local volume
  - [x] Eventually; nice pretty, branded user docs that describe creating CRD, and cases of sleep infinity vs command
  - [x] test better method from Aldo for networking

--- a/api/v1alpha1/minicluster_types.go
+++ b/api/v1alpha1/minicluster_types.go
@@ -49,10 +49,6 @@ type MiniClusterSpec struct {
 	// +optional
 	Size int32 `json:"size"`
 
-	// Run flux diagnostics on start instead of command
-	// +optional
-	Diagnostics bool `json:"diagnostics"`
-
 	// Should the job be limited to a particular number of seconds?
 	// Approximately one year. This cannot be zero or job won't start
 	// +kubebuilder:default=31500000
@@ -119,6 +115,10 @@ type MiniClusterContainer struct {
 	// Working directory to run command from
 	// +optional
 	WorkingDir string `json:"workingDir"`
+
+	// Run flux diagnostics on start instead of command
+	// +optional
+	Diagnostics bool `json:"diagnostics"`
 
 	// Ports to be exposed to other containers in the cluster
 	// We take a single list of integers and map to the same

--- a/controllers/flux/minicluster.go
+++ b/controllers/flux/minicluster.go
@@ -310,7 +310,7 @@ func generateWaitScript(cluster *api.MiniCluster, containerIndex int) (string, e
 		FluxToken:         uuid.New().String(),
 		MainHost:          mainHost,
 		Hosts:             hosts,
-		Diagnostics:       cluster.Spec.Diagnostics,
+		Diagnostics:       container.Diagnostics,
 		FluxOptionFlags:   container.FluxOptionFlags,
 		PreCommand:        container.PreCommand,
 		ClusterSize:       cluster.Spec.Size,

--- a/controllers/flux/templates/wait.sh
+++ b/controllers/flux/templates/wait.sh
@@ -194,8 +194,6 @@ else
             ${asFlux} flux start -o --config /etc/flux/config ${brokerOptions} flux mini run {{if .Size }}-n {{.Size}}{{ end }} {{ if .FluxOptionFlags }}{{ .FluxOptionFlags}}{{ end }} $@
         fi
     else 
-        printf "\n😪 Sleeping to give RESTful server time to start...\n"
-
         # Just run start on worker nodes, with some delay to let rank 0 start first
         printf "\n🌀${asFlux} flux start -o --config /etc/flux/config ${brokerOptions}\n"
 
@@ -203,7 +201,7 @@ else
         while true
         do
             ${asFlux} flux start -o --config /etc/flux/config ${brokerOptions}
-            sleep 5
+            sleep 15
         done
     fi
 fi

--- a/docs/getting_started/custom-resource-definition.md
+++ b/docs/getting_started/custom-resource-definition.md
@@ -57,17 +57,6 @@ and then determine if the test was successful based on this output.
   test: true
 ```
 
-### diagnostics
-
-Flux has a command that makes it easy to run diagnostics on a cluster, and we expose a boolean that makes it possible
-to run that (instead of your job or starting the server). To enable this, set this boolean to true. By default, it is false.
-
-```yaml
-  # Diagnostics runs flux commands for diagnostics, and a final sleep command
-  # That makes it easy for you to shell into the pod to look around
-  diagnostics: false
-```
-
 ### deadline
 
 This is the maximum running time for your job. If you leave unset, it is essentially infinite.
@@ -282,6 +271,20 @@ that is not a flux runner, you should write it into your own entrypoint.
     * Bullet
     * Points
 ```
+
+#### diagnostics
+
+Flux has a command that makes it easy to run diagnostics on a cluster, and we expose a boolean that makes it possible
+to run that (instead of your job or starting the server). Since you might only want this for a specific container,
+we provide this argument on the level of the container. To enable this, set this boolean to true. By default, it is false.
+
+```yaml
+  # Diagnostics runs flux commands for diagnostics, and a final sleep command
+  # That makes it easy for you to shell into the pod to look around
+  diagnostics: false
+```
+
+
 
 ### fluxRestful
 

--- a/examples/tests/lammps/minicluster-lammps.yaml
+++ b/examples/tests/lammps/minicluster-lammps.yaml
@@ -13,10 +13,6 @@ spec:
   # Disable verbose output
   test: true
 
-  # Diagnostics runs flux commands for diagnostics, and a final sleep command
-  # That makes it easy for you to shell into the pod to look around
-  diagnostics: false
-
   # This is a list because a pod can support multiple containers
   containers:
     # The container URI to pull (currently needs to be public)

--- a/script/check-output.sh
+++ b/script/check-output.sh
@@ -17,7 +17,9 @@ echo "Pod: ${pod}"
 # Prepare actual and tested comparison
 expected=${TEST_DIR}/test.out.correct
 actual=${TEST_DIR}/test.out
-kubectl logs -n ${NAMESPACE} ${pod} -f > ${actual} 2>&1
+
+# Fallback to assuming more than one container (and wanting to see flux)
+kubectl logs -n ${NAMESPACE} ${pod} -f > ${actual} 2>&1 || kubectl logs -n ${NAMESPACE} ${pod} flux-sample-1 -f > ${actual} 2>&1
 
 echo "Actual:"
 cat ${actual}


### PR DESCRIPTION
I am also testing increasing the default sleep for one-off commands, and falling back to using log.sh with a named container for a two container test case. I am running the current "two container" use case now (code is private hence I can't add here) and likely should add a dummy example for a test for one soon.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>