### PR TITLE
testing generation of yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,6 +221,11 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
+.PHONY: build-config
+build-config: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	$(KUSTOMIZE) build config/default > examples/dist/flux-operator.yaml
+
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -

--- a/docs/development/developer-guide.md
+++ b/docs/development/developer-guide.md
@@ -269,6 +269,17 @@ $ make catalog-build
 $ make catalog-push
 ```
 
+## Build Operator Yaml
+
+To generate the CRD to install to a cluster, we've added a `make build-config` command:
+
+```bash
+$ make build-config
+```
+
+That will generate a yaml to install the operator (with default container image) to a
+cluster in `examples/dist`.
+
 ## Container Requirements
 
 If you are looking to build a container to use with the Flux Operator, we have a set of

--- a/examples/dist/flux-operator.yaml
+++ b/examples/dist/flux-operator.yaml
@@ -1,0 +1,781 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: operator-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.0
+  creationTimestamp: null
+  name: miniclusters.flux-framework.org
+spec:
+  group: flux-framework.org
+  names:
+    kind: MiniCluster
+    listKind: MiniClusterList
+    plural: miniclusters
+    singular: minicluster
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MiniCluster is the Schema for a Flux job launcher on K8s
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MiniCluster defines the desired state of a Flux MiniCluster
+              "I am a Flux user and I want to launch a MiniCluster for my job!" A
+              MiniCluster corresponds to a Batch Job -> StatefulSet + ConfigMaps A
+              "task" within that cluster is flux running something.
+            properties:
+              containers:
+                description: Containers is one or more containers to be created in
+                  a pod. There should only be one container to run flux with runFlux
+                items:
+                  properties:
+                    command:
+                      description: 'Single user executable to provide to flux start
+                        IMPORTANT: This is left here, but not used in favor of exposing
+                        Flux via a Restful API. We Can remove this when that is finalized.'
+                      type: string
+                    diagnostics:
+                      description: Run flux diagnostics on start instead of command
+                      type: boolean
+                    environment:
+                      additionalProperties:
+                        type: string
+                      description: Key/value pairs for the environment
+                      type: object
+                    fluxLogLevel:
+                      default: 6
+                      description: Log level to use for flux logging (only in non
+                        TestMode)
+                      format: int32
+                      type: integer
+                    fluxOptionFlags:
+                      description: Flux option flags, usually provided with -o optional
+                        - if needed, default option flags for the server These can
+                        also be set in the user interface to override here. This is
+                        only valid for a FluxRunner
+                      type: string
+                    image:
+                      default: fluxrm/flux-sched:focal
+                      description: Container image must contain flux and flux-sched
+                        install
+                      type: string
+                    imagePullSecret:
+                      description: Allow the user to pull authenticated images By
+                        default no secret is selected. Setting this with the name
+                        of an already existing imagePullSecret will specify that secret
+                        in the pod spec.
+                      type: string
+                    name:
+                      description: Container name is only required for non flux runners
+                      type: string
+                    ports:
+                      description: Ports to be exposed to other containers in the
+                        cluster We take a single list of integers and map to the same
+                      items:
+                        format: int32
+                        type: integer
+                      type: array
+                    postStartExec:
+                      description: Lifecycle can handle post start commands, etc.
+                      type: string
+                    preCommand:
+                      description: Special command to run at beginning of script,
+                        directly after asFlux is defined as sudo -u flux -E (so you
+                        can change that if desired.) This is only valid if FluxRunner
+                        is set (that writes a wait.sh script)
+                      type: string
+                    pullAlways:
+                      default: false
+                      description: Allow the user to dictate pulling By default we
+                        pull if not present. Setting this to true will indicate to
+                        pull always
+                      type: boolean
+                    runFlux:
+                      description: Main container to run flux (only should be one)
+                      type: boolean
+                    volumes:
+                      additionalProperties:
+                        description: A Container volume must reference one defined
+                          for the MiniCluster The path here is in the container
+                        properties:
+                          path:
+                            type: string
+                          readOnly:
+                            default: true
+                            type: boolean
+                        required:
+                        - path
+                        type: object
+                      description: Volumes that can be mounted (must be defined in
+                        volumes)
+                      type: object
+                    workingDir:
+                      description: Working directory to run command from
+                      type: string
+                  required:
+                  - image
+                  type: object
+                type: array
+              deadlineSeconds:
+                default: 31500000
+                description: Should the job be limited to a particular number of seconds?
+                  Approximately one year. This cannot be zero or job won't start
+                format: int64
+                type: integer
+              fluxRestful:
+                description: Customization to Flux Restful API There should only be
+                  one container to run flux with runFlux
+                properties:
+                  branch:
+                    default: main
+                    description: Branch to clone Flux Restful API from
+                    type: string
+                  port:
+                    default: 5000
+                    description: Port to run Flux Restful Server On
+                    format: int32
+                    type: integer
+                type: object
+              localDeploy:
+                default: false
+                description: localDeploy should be true for development, or deploying
+                  in the case that there isn't an actual kubernetes cluster (e.g.,
+                  you are not using make deploy. It uses a persistent volume instead
+                  of a claim
+                type: boolean
+              size:
+                default: 1
+                description: Size (number of jobs to run)
+                format: int32
+                type: integer
+              test:
+                default: false
+                description: Test mode silences all output so the job only shows the
+                  test running
+                type: boolean
+              volumes:
+                additionalProperties:
+                  description: Mini Cluster local volumes available to mount (these
+                    are on the host)
+                  properties:
+                    path:
+                      type: string
+                  required:
+                  - path
+                  type: object
+                description: Volumes on the host (named) accessible to containers
+                type: object
+            required:
+            - containers
+            type: object
+          status:
+            description: MiniClusterStatus defines the observed state of Flux
+            properties:
+              conditions:
+                description: conditions hold the latest Flux Job and MiniCluster states
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              jobid:
+                description: The JobUid is set internally to associate to a miniCluster
+                type: string
+            required:
+            - jobid
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: operator-controller-manager
+  namespace: operator-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: operator-leader-election-role
+  namespace: operator-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: operator-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - nodes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - exec
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs/status
+  verbs:
+  - create
+  - delete
+  - exec
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - ""
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - batch
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - networks
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - flux-framework.org
+  resources:
+  - clusters
+  - clusters/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - flux-framework.org
+  resources:
+  - machineclasses
+  - machinedeployments
+  - machinedeployments/status
+  - machines
+  - machines/status
+  - machinesets
+  - machinesets/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - flux-framework.org
+  resources:
+  - miniclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - flux-framework.org
+  resources:
+  - miniclusters/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - flux-framework.org
+  resources:
+  - miniclusters/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: operator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: operator-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: operator-leader-election-rolebinding
+  namespace: operator-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: operator-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: operator-controller-manager
+  namespace: operator-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: operator-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: operator-manager-role
+subjects:
+- kind: ServiceAccount
+  name: operator-controller-manager
+  namespace: operator-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: operator-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: operator-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: operator-controller-manager
+  namespace: operator-system
+---
+apiVersion: v1
+data:
+  controller_manager_config.yaml: |
+    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    kind: ControllerManagerConfig
+    health:
+      healthProbeBindAddress: :8081
+    metrics:
+      bindAddress: 127.0.0.1:8080
+    webhook:
+      port: 9443
+    leaderElection:
+      leaderElect: true
+      resourceName: 14dde902.flux-framework.org
+kind: ConfigMap
+metadata:
+  name: operator-manager-config
+  namespace: operator-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: operator-controller-manager-metrics-service
+  namespace: operator-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: operator-controller-manager
+  namespace: operator-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+      - args:
+        - --health-probe-bind-address=:8081
+        - --metrics-bind-address=127.0.0.1:8080
+        - --leader-elect
+        command:
+        - /manager
+        image: ghcr.io/flux-framework/flux-operator:latest
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: operator-controller-manager
+      terminationGracePeriodSeconds: 10


### PR DESCRIPTION
I want to see if it is possible to install the operator via just a yaml that points to a container, without needing to clone and do make deploy. It will depend on if the URLs provided here are relative to my cluster (e.g., 0.0.0.0 and 127.0.0.1) vs generic for any cluster (and relative to the pod node).

Signed-off-by: vsoch <vsoch@users.noreply.github.com>