### PR TITLE
add check that make build-config was run

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,14 @@ jobs:
     # These aren't written yet)
     - name: Run Unit tests
       run: make test
-        
+
+    # Ensure build-config is the same as the one we have
+    - name: Check Updated flux-operator.yaml
+      run: |
+        cp examples/dist/flux-operator.yaml /tmp/flux-operator.yaml
+        make build-config
+        diff examples/dist/flux-operator.yaml /tmp/flux-operator.yaml
+
   test-jobs:
     needs: [unit-tests]
     runs-on: ubuntu-latest

--- a/docs/getting_started/custom-resource-definition.md
+++ b/docs/getting_started/custom-resource-definition.md
@@ -239,7 +239,7 @@ Providing (or not providing) a command is going to dictate the behavior of your 
     command: lmp -v x 2 -v y 2 -v z 2 -in in.reaxc.hns -nocite
 ```
 
-### resources
+#### resources
 
 Resources can include limits and requests. Known keys include "memory" and "cpu" (should be provided in some
 string format that can be parsed) and all others are considered some kind of quantity request. 
@@ -408,7 +408,8 @@ we provide this argument on the level of the container. To enable this, set this
 
 ### volumes
 
-Volumes that are defined on the level of the MiniCluster (named) can be mounted into containers.
+Volumes that are defined on the level of the MiniCluster can be referenced on the level
+of the container to be mounted into them.
 As an example, here is how we specify the volume `myvolume` to be mounted to the container at `/data`.
 
 ```yaml
@@ -418,7 +419,9 @@ volumes:
 ```
 
 The `myvolume` key must be defined in the MiniCluster set of volumes, and this is checked.
-
+Also note that we currently don't support shared filesystem volumes for production
+Kubernetes deploys - this only works for a local deploy on your host. We will
+work on this soon.
 
 ### fluxRestful
 

--- a/docs/getting_started/custom-resource-definition.md
+++ b/docs/getting_started/custom-resource-definition.md
@@ -152,6 +152,10 @@ logging:
 By default timed is set to `false` above, and this is because if you turn it on your Flux runner
 container is required to have `time` installed. We target `/usr/bin/time` and not the `time`
 wrapper because we want to set a format with `-f` (which won't be supported by the wrapper).
+By default we ask for `-f E` which means:
+
+> Elapsed real (wall clock) time used by the process, in [hours:]minutes:seconds.
+
 Also note that `timed` and `quiet` can influence one another - e.g., if quiet is `true` and
 there are some timed sections under a section that is no longer included when the job
 is quiet, you will not see those times. Here is an example of timing a hello-world run:


### PR DESCRIPTION
This will close #70 - I think the check is fine in favor of having to deploy it somewhere else. I also think the flux-operator.yaml on the branch should consistently be provided that matches the state of the branch.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>