### PR TITLE
add time for flux submit and flux start

### DIFF
--- a/controllers/flux/templates/wait.sh
+++ b/controllers/flux/templates/wait.sh
@@ -182,13 +182,13 @@ else
             # -o is an "option" for the broker
             # -S corresponds to a shortened --setattr=ATTR=VAL
             printf "\n🌀 flux start -o --config /etc/flux/config ${brokerOptions} ${startServer}\n"{{ end }}
-            {{ if .Logging.TimedMode }}/usr/bin/time -f "FLUXTIME fluxstart wall time %E" {{ end }}${asFlux} flux start -o --config /etc/flux/config ${brokerOptions} ${startServer}
+            {{ if .Logging.TimedMode }}/usr/bin/time -f "FLUXTIME fluxstart wall time %E" {{ end }}${asFlux} flux start -o --config /etc/flux/config ${brokerOptions} {{ if .Logging.TimedMode }}/usr/bin/time -f "FLUXTIME fluxsubmit wall time %E" {{ end }} ${startServer}
 
         # Case 2: Fall back to provided command
         else
 {{ if not .Logging.QuietMode }} 
             printf "\n🌀 flux start -o --config /etc/flux/config ${brokerOptions} flux mini submit {{ if gt .Tasks .Size }} -N {{.Size}}{{ end }} -n {{.Tasks}} --quiet {{ if .FluxOptionFlags }}{{ .FluxOptionFlags}}{{ end }} --watch{{ if .Logging.DebugMode }} -vvv{{ end }} $@\n"{{ end }}
-            {{ if .Logging.TimedMode }}/usr/bin/time -f "FLUXTIME fluxsubmit wall time %E" {{ end }}${asFlux} flux start -o --config /etc/flux/config ${brokerOptions} flux mini submit {{ if gt .Tasks .Size }} -N {{.Size}}{{ end }} -n {{.Tasks}} --quiet {{ if .FluxOptionFlags }}{{ .FluxOptionFlags}}{{ end }} --watch{{ if .Logging.DebugMode }} -vvv{{ end }} $@
+            {{ if .Logging.TimedMode }}/usr/bin/time -f "FLUXTIME fluxstart wall time %E" {{ end }}${asFlux} flux start -o --config /etc/flux/config ${brokerOptions} {{ if .Logging.TimedMode }}/usr/bin/time -f "FLUXTIME fluxsubmit wall time %E" {{ end }} flux mini submit {{ if gt .Tasks .Size }} -N {{.Size}}{{ end }} -n {{.Tasks}} --quiet {{ if .FluxOptionFlags }}{{ .FluxOptionFlags}}{{ end }} --watch{{ if .Logging.DebugMode }} -vvv{{ end }} $@
         fi
     else
         # Sleep until the broker is ready


### PR DESCRIPTION
This shows there is quite a difference between flux start and flux mini submit, already in test cases.

```
Pods: flux-sample-0-fq6wb flux-sample-1-gqcht flux-sample-2-nvrvc flux-sample-3-zmfwn flux-sample-cert-generator
Pod: flux-sample-0-fq6wb
Actual:
hello world
FLUXTIME fluxsubmit wall time 0:00.30
FLUXTIME fluxstart wall time 0:16.59
```
This would be interesting to measure when all pods stay up.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>