### PR TITLE
fluxoperator python sdk client should time things

### DIFF
--- a/sdk/python/v1alpha1/CHANGELOG.md
+++ b/sdk/python/v1alpha1/CHANGELOG.md
@@ -15,6 +15,8 @@ The versions coincide with releases on pip. Only major versions will be released
 
 ## [0.0.x](https://github.com/flux-framework/flux-operator/tree/main/sdk/python/v2alpha1) (0.0.x)
  - Support for operator client wait_pods_terminated (0.0.12)
+   - Basic functions to create/delete minicluster
+   - Times saved to FluxOperator client for most actions
  - Bug with default args not being provided fixed (0.0.11)
  - Addition of FluxOperator client to wait for pods and port forward (0.0.1)
  - Skeleton creation of project (0.0.0)

--- a/sdk/python/v1alpha1/fluxoperator/client.py
+++ b/sdk/python/v1alpha1/fluxoperator/client.py
@@ -2,6 +2,8 @@ from kubernetes import client
 from kubernetes.client.api import core_v1_api
 from contextlib import contextmanager
 from .resource.network import port_forward
+from .resource.pods import create_minicluster, delete_minicluster
+from .decorator import timed
 
 import requests
 import time
@@ -15,41 +17,57 @@ class FluxOperator:
         This currently assumes the namespace exists.
         """
         self.namespace = namespace
+        self._core_v1 = None
+        self.times = {}
+
+    @property
+    def core_v1(self):
+        """
+        Instantiate a core_v1 api (if not done yet)
+
+        We have this here because we typically need to create the MiniCluster
+        first.
+        """
+        if self._core_v1 is not None:
+            return self._core_v1
+
         self.c = client.Configuration.get_default_copy()
         self.c.assert_hostname = False
         client.Configuration.set_default(self.c)
-        self.core_v1 = core_v1_api.CoreV1Api()
+        self._core_v1 = core_v1_api.CoreV1Api()
+        return self._core_v1
 
     @contextmanager
-    def port_forward(self, pod):
+    def port_forward(self, pod, retry_seconds=1):
         """
         Wrapper to the port forward with context
         """
+        start = time.time()
         with port_forward(self.core_v1):
             # Wait until this url is actually ready. In practice about 10-15 seconds
             url = f"http://{pod.metadata.name}.pod.flux-operator.kubernetes:5000"
             print()
             print(f"Waiting for {url} to be ready")
-            sleep = 2
             ready = False
             while not ready:
-                time.sleep(sleep)
+                time.sleep(retry_seconds)
                 try:
                     response = requests.get(url)
                     if response.status_code == 200:
-                        print("🪅️ RestFUL API server is ready!")
+                        end = time.time()
+                        print("🪅️  RestFUL API server is ready!")
                         ready = True
+                        self.times["restful_api_server_ready_seconds"] = end - start
 
                 # There will be a few connection errors before everything is ready
                 except Exception:
                     pass
                 print(".", end="\r")
-                sleep = sleep * 2
 
             print()
             yield url
 
-    def wait_termination_pods(self):
+    def wait_termination_pods(self, retry_seconds=1):
         """
         Ensure the namespace of pods is cleaned up before contining.
         """
@@ -59,10 +77,28 @@ class FluxOperator:
             if len(pod_list.items) == 0:
                 ready = True
                 break
-            time.sleep(2)
-        print(f'All pods are terminated.')
+            time.sleep(retry_seconds)
+        print("All pods are terminated.")
 
-    def wait_pods(self, states=None):
+    @timed
+    def create_minicluster(self, name, size, image, namespace, user=None, token=None):
+        """
+        Create (and time the creation of) the MiniCluster
+        """
+        res = create_minicluster(name, size, image, namespace, user=user, token=token)
+        self.wait_pods()
+        return res
+
+    @timed
+    def delete_minicluster(self, name, namespace):
+        """
+        Deletion (and time the deletion of) the MiniCluster
+        """
+        res = delete_minicluster(name, namespace)
+        self.wait_termination_pods()
+        return res
+
+    def wait_pods(self, states=None, retry_seconds=1):
         """
         Wait for all pods to be running or completed (or in a specific set of states)
         """
@@ -76,7 +112,7 @@ class FluxOperator:
             ready = False
             for pod in pod_list.items:
                 if pod.status.phase not in states:
-                    time.sleep(2)
+                    time.sleep(retry_seconds)
                     continue
             # If we get down here, pods are ready
             ready = True

--- a/sdk/python/v1alpha1/fluxoperator/client.py
+++ b/sdk/python/v1alpha1/fluxoperator/client.py
@@ -1,4 +1,4 @@
-from kubernetes import client
+from kubernetes import client, watch
 from kubernetes.client.api import core_v1_api
 from contextlib import contextmanager
 from .resource.network import port_forward
@@ -67,7 +67,41 @@ class FluxOperator:
             print()
             yield url
 
-    def wait_termination_pods(self, retry_seconds=1):
+    def stream_output(self, filename, pod=None, stdout=True):
+        """
+        Stream output, optionally printing also to stdout.
+        """
+        if pod is None:
+            pod = self.get_broker_pod()
+
+        watcher = watch.Watch()
+
+        # Stream output to file (should we return output too?)
+        with open(filename, "w") as fd:
+            for line in watcher.stream(
+                self.core_v1.read_namespaced_pod_log,
+                name=pod.metadata.name,
+                namespace=self.namespace,
+                follow=True,
+            ):
+                # Lines end with /r and we need to strip and add a newline
+                fd.write(line.strip() + "\n")
+                if stdout:
+                    print(line)
+
+    def get_pods(self):
+        """
+        Get namespaced pods metadata
+        """
+        return self.core_v1.list_namespaced_pod(self.namespace)
+
+    def get_nodes(self):
+        """
+        Get nodes metadata
+        """
+        return self.core_v1.list_node()
+
+    def wait_termination_pods(self, retry_seconds=1, quiet=False):
         """
         Ensure the namespace of pods is cleaned up before contining.
         """
@@ -78,14 +112,15 @@ class FluxOperator:
                 ready = True
                 break
             time.sleep(retry_seconds)
-        print("All pods are terminated.")
+        if not quiet:
+            print("All pods are terminated.")
 
     @timed
-    def create_minicluster(self, name, size, image, namespace, user=None, token=None):
+    def create_minicluster(self, *args, **kwargs):
         """
         Create (and time the creation of) the MiniCluster
         """
-        res = create_minicluster(name, size, image, namespace, user=user, token=token)
+        res = create_minicluster(*args, **kwargs)
         self.wait_pods()
         return res
 
@@ -98,7 +133,7 @@ class FluxOperator:
         self.wait_termination_pods()
         return res
 
-    def wait_pods(self, states=None, retry_seconds=1):
+    def wait_pods(self, states=None, retry_seconds=1, quiet=False):
         """
         Wait for all pods to be running or completed (or in a specific set of states)
         """
@@ -117,22 +152,23 @@ class FluxOperator:
             # If we get down here, pods are ready
             ready = True
 
-        states = '" or "'.join(states)
-        print(f'All pods are in states "{states}"')
+        if not quiet:
+            states = '" or "'.join(states)
+            print(f'All pods are in states "{states}"')
 
-    def get_broker_pod(self):
+    def get_broker_pod(self, quiet=True):
         """
         Given a core_v1 connection and namespace, get the broker pod.
         """
         # All pods required to be ready
-        self.wait_pods()
+        self.wait_pods(quiet=quiet)
 
-        # Go through process again and get broker
+        # Go through process again and get broker, must be running!
         brokerPod = None
         while not brokerPod:
             pod_list = self.core_v1.list_namespaced_pod(self.namespace)
             for pod in pod_list.items:
-                if "-0" in pod.metadata.name:
+                if "-0" in pod.metadata.name and pod.status.phase in ["Running"]:
                     print(f"Found broker pod {pod.metadata.name}")
                     brokerPod = pod
         return brokerPod

--- a/sdk/python/v1alpha1/fluxoperator/decorator.py
+++ b/sdk/python/v1alpha1/fluxoperator/decorator.py
@@ -18,8 +18,8 @@ class timed(Decorator):
 
     def __call__(self, cls, *args, **kwargs):
         # Name of the key is after command
-        if "name" in kwargs:
-            key = kwargs["name"]
+        if "timed_name" in kwargs:
+            key = kwargs["timed_name"]
         # Fallback to name of function
         else:
             key = self.func.__name__

--- a/sdk/python/v1alpha1/fluxoperator/decorator.py
+++ b/sdk/python/v1alpha1/fluxoperator/decorator.py
@@ -1,0 +1,31 @@
+import time
+from functools import partial, update_wrapper
+
+
+class Decorator:
+    def __init__(self, func):
+        update_wrapper(self, func)
+        self.func = func
+
+    def __get__(self, obj, objtype):
+        return partial(self.__call__, obj)
+
+
+class timed(Decorator):
+    """
+    Time the length of the run, add to times
+    """
+
+    def __call__(self, cls, *args, **kwargs):
+        # Name of the key is after command
+        if "name" in kwargs:
+            key = kwargs["name"]
+        # Fallback to name of function
+        else:
+            key = self.func.__name__
+
+        start = time.time()
+        res = self.func(cls, *args, **kwargs)
+        end = time.time()
+        cls.times[key] = round(end - start, 3)
+        return res

--- a/sdk/python/v1alpha1/fluxoperator/defaults.py
+++ b/sdk/python/v1alpha1/fluxoperator/defaults.py
@@ -1,0 +1,2 @@
+# Flux Operator Python SDK defaults
+flux_operator_api_version = "v1alpha1"

--- a/sdk/python/v1alpha1/fluxoperator/resource/pods.py
+++ b/sdk/python/v1alpha1/fluxoperator/resource/pods.py
@@ -1,0 +1,63 @@
+from kubernetes.client import V1ObjectMeta
+from kubernetes import client, config
+import fluxoperator.models as models
+
+import fluxoperator.defaults as defaults
+
+
+def create_minicluster(name, size, image, namespace, user=None, token=None):
+    """
+    Create a MiniCluster of a particular size to run an image.
+
+    This currently assumes running in single-user mode.
+    """
+    # The cluster should be running with the operator installed
+    config.load_kube_config()
+    crd_api = client.CustomObjectsApi()
+
+    # We assume that this is a single container to run flux
+    # Multi-container support can eventually be added.
+    container = models.MiniClusterContainer(image=image, run_flux=True)
+
+    # Flux Restful pre-determined user and token
+    flux_restful = None
+    if user is not None and token is not None:
+        flux_restful = models.FluxRestful(username=user, token=token)
+
+    # Create the MiniCluster
+    minicluster = models.MiniCluster(
+        kind="MiniCluster",
+        api_version=f"flux-framework.org/{defaults.flux_operator_api_version}",
+        metadata=V1ObjectMeta(name=name, namespace=namespace),
+        spec=models.MiniClusterSpec(
+            flux_restful=flux_restful,
+            size=size,
+            containers=[container],
+        ),
+    )
+
+    # Note that you might want to do this first for minikube
+    # minikube ssh docker pull ghcr.io/rse-ops/accounting:app-latest
+    return crd_api.create_namespaced_custom_object(
+        group="flux-framework.org",
+        version=defaults.flux_operator_api_version,
+        namespace=namespace,
+        plural="miniclusters",
+        body=minicluster,
+    )
+
+
+def delete_minicluster(name, namespace):
+    """
+    Delete a named MiniCluster.
+    """
+    config.load_kube_config()
+    crd_api = client.CustomObjectsApi()
+
+    return crd_api.delete_namespaced_custom_object(
+        group="flux-framework.org",
+        version=defaults.flux_operator_api_version,
+        namespace=namespace,
+        plural="miniclusters",
+        name=name,
+    )

--- a/sdk/python/v1alpha1/fluxoperator/resource/pods.py
+++ b/sdk/python/v1alpha1/fluxoperator/resource/pods.py
@@ -3,26 +3,137 @@ from kubernetes import client, config
 import fluxoperator.models as models
 
 import fluxoperator.defaults as defaults
+import sys
+
+# These are known objects we will parse
+_objects = ["logging", "volumes", "resources", "flux_restful", "container", "resources"]
 
 
-def create_minicluster(name, size, image, namespace, user=None, token=None):
+def _get_logging_spec(logging):
+    """
+    Return models.Logging
+    """
+    logging_defaults = {"debug": False, "quiet": False, "strict": True, "timed": False}
+
+    for k, v in (logging or {}).items():
+        if k in logging_defaults and v in [True, False]:
+            logging_defaults[k] = v
+
+    return models.LoggingSpec(**logging_defaults)
+
+
+def _get_container_volumes(volumes):
+    """
+    Prepare container volumes.
+    """
+    volumeset = {}
+    for name, volume in (volumes or {}).items():
+        volume_spec = {}
+        for attr in models.ContainerVolume.attribute_map:
+            if attr in volume:
+                volume_spec[attr] = volume[attr]
+        volumeset[name] = models.ContainerVolume(**volume_spec)
+    return volumeset
+
+
+def _get_container_spec(container):
+    """
+    Get the container spec.
+    """
+    # For now only one container support, it must run Flux
+    container_kwargs = {"run_flux": True}
+    for k in models.MiniClusterContainer.attribute_map:
+        if k in container and k not in _objects:
+            container_kwargs[k] = container[k]
+        elif k in container and k == "volumes":
+            container_kwargs[k] = _get_container_volumes(container[k])
+        elif k in container and k == "resources":
+            container_kwargs["resources"] = _get_container_resources_spec(container[k])
+
+    return models.MiniClusterContainer(**container_kwargs)
+
+
+def _get_container_resources_spec(resources):
+    """
+    Get container resources spec.
+    """
+    resources = resources or {}
+    resource_spec = {}
+    for k in models.ContainerResources.attribute_map:
+        if k in resources:
+            resource_spec[k] = resources[k]
+    return models.ContainerResources(**resource_spec)
+
+
+def _get_minicluster_spec(kwargs):
+    """
+    Get the main spec for the minicluster
+    """
+    minicluster_kwargs = {}
+    for k in models.MiniClusterSpec.attribute_map:
+        if k in kwargs and k not in _objects:
+            minicluster_kwargs[k] = kwargs[k]
+    return minicluster_kwargs
+
+
+def _get_volumes_spec(volumes):
+    """
+    Prepare container volumes.
+    """
+    volumeset = {}
+    for name, volume in (volumes or {}).items():
+        volume_spec = {}
+        for attr in models.MiniClusterVolume.attribute_map:
+            if attr in volume:
+                volume_spec[attr] = volume[attr]
+        volumeset[name] = models.MiniClusterVolume(**volume_spec)
+    return volumeset
+
+
+def _get_flux_restful_spec(restful):
+    """
+    Get FluxRestful Spec
+    """
+    # Flux Restful pre-determined user and token
+    flux_restful = None
+    if restful and "username" in restful and "token" in restful:
+        flux_restful = models.FluxRestful(**restful)
+    return flux_restful
+
+
+def create_minicluster(*args, **kwargs):
     """
     Create a MiniCluster of a particular size to run an image.
 
-    This currently assumes running in single-user mode.
+    The command is optional - if not provided will start the Flux RestFul API.
+    This currently assumes running in single-user mode. The args/kwargs are
+    left generic to be able to somewhat allow passing arbitrary dicts.
     """
+    # Required to be in kwargs
+    requireds = ["namespace", "name", "container"]
+    for required in requireds:
+        if required not in kwargs:
+            sys.exit(f'A "{required}" field is required as a keyword argument.')
+
+    container = kwargs["container"]
+    namespace = kwargs["namespace"]
+    name = kwargs["name"]
+    del kwargs["container"]
+
     # The cluster should be running with the operator installed
     config.load_kube_config()
     crd_api = client.CustomObjectsApi()
 
     # We assume that this is a single container to run flux
     # Multi-container support can eventually be added.
-    container = models.MiniClusterContainer(image=image, run_flux=True)
+    # TODO when requested, add pod resources
+    container = _get_container_spec(container)
 
-    # Flux Restful pre-determined user and token
-    flux_restful = None
-    if user is not None and token is not None:
-        flux_restful = models.FluxRestful(username=user, token=token)
+    # Logging spec with pre-defined defaults
+    logging_spec = _get_logging_spec(kwargs.get("logging"))
+    flux_restful = _get_flux_restful_spec(kwargs.get("flux_restful"))
+    volumes = _get_volumes_spec(kwargs.get("volumes"))
+    minicluster_kwargs = _get_minicluster_spec(kwargs)
 
     # Create the MiniCluster
     minicluster = models.MiniCluster(
@@ -30,9 +141,11 @@ def create_minicluster(name, size, image, namespace, user=None, token=None):
         api_version=f"flux-framework.org/{defaults.flux_operator_api_version}",
         metadata=V1ObjectMeta(name=name, namespace=namespace),
         spec=models.MiniClusterSpec(
-            flux_restful=flux_restful,
-            size=size,
+            **minicluster_kwargs,
+            logging=logging_spec,
             containers=[container],
+            flux_restful=flux_restful,
+            volumes=volumes,
         ),
     )
 

--- a/sdk/python/v1alpha1/test/test_commands.py
+++ b/sdk/python/v1alpha1/test/test_commands.py
@@ -19,6 +19,7 @@ import fluxoperator
 from fluxoperator.models.commands import Commands  # noqa: E501
 from fluxoperator.rest import ApiException
 
+
 class TestCommands(unittest.TestCase):
     """Commands unit test stubs"""
 
@@ -30,23 +31,20 @@ class TestCommands(unittest.TestCase):
 
     def make_instance(self, include_optional):
         """Test Commands
-            include_option is a boolean, when False only required
-            params are included, when True both required and
-            optional params are included """
+        include_option is a boolean, when False only required
+        params are included, when True both required and
+        optional params are included"""
         # model = fluxoperator.models.commands.Commands()  # noqa: E501
-        if include_optional :
-            return Commands(
-                pre = '', 
-                run_flux_as_root = True
-            )
-        else :
-            return Commands(
-        )
+        if include_optional:
+            return Commands(pre="", run_flux_as_root=True)
+        else:
+            return Commands()
 
     def testCommands(self):
         """Test Commands"""
         inst_req_only = self.make_instance(include_optional=False)
         inst_req_and_optional = self.make_instance(include_optional=True)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/sdk/python/v1alpha1/test/test_container_resources.py
+++ b/sdk/python/v1alpha1/test/test_container_resources.py
@@ -19,6 +19,7 @@ import fluxoperator
 from fluxoperator.models.container_resources import ContainerResources  # noqa: E501
 from fluxoperator.rest import ApiException
 
+
 class TestContainerResources(unittest.TestCase):
     """ContainerResources unit test stubs"""
 
@@ -30,27 +31,20 @@ class TestContainerResources(unittest.TestCase):
 
     def make_instance(self, include_optional):
         """Test ContainerResources
-            include_option is a boolean, when False only required
-            params are included, when True both required and
-            optional params are included """
+        include_option is a boolean, when False only required
+        params are included, when True both required and
+        optional params are included"""
         # model = fluxoperator.models.container_resources.ContainerResources()  # noqa: E501
-        if include_optional :
-            return ContainerResources(
-                limits = {
-                    'key' : None
-                    }, 
-                requests = {
-                    'key' : None
-                    }
-            )
-        else :
-            return ContainerResources(
-        )
+        if include_optional:
+            return ContainerResources(limits={"key": None}, requests={"key": None})
+        else:
+            return ContainerResources()
 
     def testContainerResources(self):
         """Test ContainerResources"""
         inst_req_only = self.make_instance(include_optional=False)
         inst_req_and_optional = self.make_instance(include_optional=True)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/sdk/python/v1alpha1/test/test_container_volume.py
+++ b/sdk/python/v1alpha1/test/test_container_volume.py
@@ -19,6 +19,7 @@ import fluxoperator
 from fluxoperator.models.container_volume import ContainerVolume  # noqa: E501
 from fluxoperator.rest import ApiException
 
+
 class TestContainerVolume(unittest.TestCase):
     """ContainerVolume unit test stubs"""
 
@@ -30,24 +31,22 @@ class TestContainerVolume(unittest.TestCase):
 
     def make_instance(self, include_optional):
         """Test ContainerVolume
-            include_option is a boolean, when False only required
-            params are included, when True both required and
-            optional params are included """
+        include_option is a boolean, when False only required
+        params are included, when True both required and
+        optional params are included"""
         # model = fluxoperator.models.container_volume.ContainerVolume()  # noqa: E501
-        if include_optional :
+        if include_optional:
+            return ContainerVolume(path="", read_only=True)
+        else:
             return ContainerVolume(
-                path = '', 
-                read_only = True
+                path="",
             )
-        else :
-            return ContainerVolume(
-                path = '',
-        )
 
     def testContainerVolume(self):
         """Test ContainerVolume"""
         inst_req_only = self.make_instance(include_optional=False)
         inst_req_and_optional = self.make_instance(include_optional=True)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/sdk/python/v1alpha1/test/test_flux_restful.py
+++ b/sdk/python/v1alpha1/test/test_flux_restful.py
@@ -19,6 +19,7 @@ import fluxoperator
 from fluxoperator.models.flux_restful import FluxRestful  # noqa: E501
 from fluxoperator.rest import ApiException
 
+
 class TestFluxRestful(unittest.TestCase):
     """FluxRestful unit test stubs"""
 
@@ -30,25 +31,20 @@ class TestFluxRestful(unittest.TestCase):
 
     def make_instance(self, include_optional):
         """Test FluxRestful
-            include_option is a boolean, when False only required
-            params are included, when True both required and
-            optional params are included """
+        include_option is a boolean, when False only required
+        params are included, when True both required and
+        optional params are included"""
         # model = fluxoperator.models.flux_restful.FluxRestful()  # noqa: E501
-        if include_optional :
-            return FluxRestful(
-                branch = '', 
-                port = 56, 
-                token = '', 
-                username = ''
-            )
-        else :
-            return FluxRestful(
-        )
+        if include_optional:
+            return FluxRestful(branch="", port=56, token="", username="")
+        else:
+            return FluxRestful()
 
     def testFluxRestful(self):
         """Test FluxRestful"""
         inst_req_only = self.make_instance(include_optional=False)
         inst_req_and_optional = self.make_instance(include_optional=True)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/sdk/python/v1alpha1/test/test_flux_user.py
+++ b/sdk/python/v1alpha1/test/test_flux_user.py
@@ -19,6 +19,7 @@ import fluxoperator
 from fluxoperator.models.flux_user import FluxUser  # noqa: E501
 from fluxoperator.rest import ApiException
 
+
 class TestFluxUser(unittest.TestCase):
     """FluxUser unit test stubs"""
 
@@ -30,23 +31,20 @@ class TestFluxUser(unittest.TestCase):
 
     def make_instance(self, include_optional):
         """Test FluxUser
-            include_option is a boolean, when False only required
-            params are included, when True both required and
-            optional params are included """
+        include_option is a boolean, when False only required
+        params are included, when True both required and
+        optional params are included"""
         # model = fluxoperator.models.flux_user.FluxUser()  # noqa: E501
-        if include_optional :
-            return FluxUser(
-                name = '', 
-                uid = 56
-            )
-        else :
-            return FluxUser(
-        )
+        if include_optional:
+            return FluxUser(name="", uid=56)
+        else:
+            return FluxUser()
 
     def testFluxUser(self):
         """Test FluxUser"""
         inst_req_only = self.make_instance(include_optional=False)
         inst_req_and_optional = self.make_instance(include_optional=True)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/sdk/python/v1alpha1/test/test_life_cycle.py
+++ b/sdk/python/v1alpha1/test/test_life_cycle.py
@@ -19,6 +19,7 @@ import fluxoperator
 from fluxoperator.models.life_cycle import LifeCycle  # noqa: E501
 from fluxoperator.rest import ApiException
 
+
 class TestLifeCycle(unittest.TestCase):
     """LifeCycle unit test stubs"""
 
@@ -30,22 +31,20 @@ class TestLifeCycle(unittest.TestCase):
 
     def make_instance(self, include_optional):
         """Test LifeCycle
-            include_option is a boolean, when False only required
-            params are included, when True both required and
-            optional params are included """
+        include_option is a boolean, when False only required
+        params are included, when True both required and
+        optional params are included"""
         # model = fluxoperator.models.life_cycle.LifeCycle()  # noqa: E501
-        if include_optional :
-            return LifeCycle(
-                post_start_exec = ''
-            )
-        else :
-            return LifeCycle(
-        )
+        if include_optional:
+            return LifeCycle(post_start_exec="")
+        else:
+            return LifeCycle()
 
     def testLifeCycle(self):
         """Test LifeCycle"""
         inst_req_only = self.make_instance(include_optional=False)
         inst_req_and_optional = self.make_instance(include_optional=True)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/sdk/python/v1alpha1/test/test_logging_spec.py
+++ b/sdk/python/v1alpha1/test/test_logging_spec.py
@@ -19,6 +19,7 @@ import fluxoperator
 from fluxoperator.models.logging_spec import LoggingSpec  # noqa: E501
 from fluxoperator.rest import ApiException
 
+
 class TestLoggingSpec(unittest.TestCase):
     """LoggingSpec unit test stubs"""
 
@@ -30,25 +31,20 @@ class TestLoggingSpec(unittest.TestCase):
 
     def make_instance(self, include_optional):
         """Test LoggingSpec
-            include_option is a boolean, when False only required
-            params are included, when True both required and
-            optional params are included """
+        include_option is a boolean, when False only required
+        params are included, when True both required and
+        optional params are included"""
         # model = fluxoperator.models.logging_spec.LoggingSpec()  # noqa: E501
-        if include_optional :
-            return LoggingSpec(
-                debug = True, 
-                quiet = True, 
-                strict = True, 
-                timed = True
-            )
-        else :
-            return LoggingSpec(
-        )
+        if include_optional:
+            return LoggingSpec(debug=True, quiet=True, strict=True, timed=True)
+        else:
+            return LoggingSpec()
 
     def testLoggingSpec(self):
         """Test LoggingSpec"""
         inst_req_only = self.make_instance(include_optional=False)
         inst_req_and_optional = self.make_instance(include_optional=True)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/sdk/python/v1alpha1/test/test_mini_cluster.py
+++ b/sdk/python/v1alpha1/test/test_mini_cluster.py
@@ -19,6 +19,7 @@ import fluxoperator
 from fluxoperator.models.mini_cluster import MiniCluster  # noqa: E501
 from fluxoperator.rest import ApiException
 
+
 class TestMiniCluster(unittest.TestCase):
     """MiniCluster unit test stubs"""
 
@@ -30,108 +31,105 @@ class TestMiniCluster(unittest.TestCase):
 
     def make_instance(self, include_optional):
         """Test MiniCluster
-            include_option is a boolean, when False only required
-            params are included, when True both required and
-            optional params are included """
+        include_option is a boolean, when False only required
+        params are included, when True both required and
+        optional params are included"""
         # model = fluxoperator.models.mini_cluster.MiniCluster()  # noqa: E501
-        if include_optional :
+        if include_optional:
             return MiniCluster(
-                api_version = '', 
-                kind = '', 
-                metadata = None, 
-                spec = fluxoperator.models.mini_cluster_spec.MiniClusterSpec(
-                    cleanup = True, 
-                    containers = [
+                api_version="",
+                kind="",
+                metadata=None,
+                spec=fluxoperator.models.mini_cluster_spec.MiniClusterSpec(
+                    cleanup=True,
+                    containers=[
                         fluxoperator.models.mini_cluster_container.MiniClusterContainer(
-                            command = '', 
-                            commands = fluxoperator.models.commands.Commands(
-                                pre = '', 
-                                run_flux_as_root = True, ), 
-                            cores = 56, 
-                            diagnostics = True, 
-                            environment = {
-                                'key' : ''
-                                }, 
-                            flux_log_level = 56, 
-                            flux_option_flags = '', 
-                            flux_user = fluxoperator.models.flux_user.FluxUser(
-                                name = '', 
-                                uid = 56, ), 
-                            image = '', 
-                            image_pull_secret = '', 
-                            life_cycle = fluxoperator.models.life_cycle.LifeCycle(
-                                post_start_exec = '', ), 
-                            name = '', 
-                            ports = [
-                                56
-                                ], 
-                            pre_command = '', 
-                            pull_always = True, 
-                            resources = fluxoperator.models.container_resources.ContainerResources(
-                                limits = {
-                                    'key' : None
-                                    }, 
-                                requests = {
-                                    'key' : None
-                                    }, ), 
-                            run_flux = True, 
-                            volumes = {
-                                'key' : fluxoperator.models.container_volume.ContainerVolume(
-                                    path = '', 
-                                    read_only = True, )
-                                }, 
-                            working_dir = '', )
-                        ], 
-                    deadline_seconds = 56, 
-                    flux_restful = fluxoperator.models.flux_restful.FluxRestful(
-                        branch = '', 
-                        port = 56, 
-                        token = '', 
-                        username = '', ), 
-                    job_labels = {
-                        'key' : ''
-                        }, 
-                    logging = fluxoperator.models.logging_spec.LoggingSpec(
-                        debug = True, 
-                        quiet = True, 
-                        strict = True, 
-                        timed = True, ), 
-                    pod = fluxoperator.models.pod_spec.PodSpec(
-                        annotations = {
-                            'key' : ''
-                            }, 
-                        labels = {
-                            'key' : ''
-                            }, ), 
-                    size = 56, 
-                    tasks = 56, 
-                    users = [
+                            command="",
+                            commands=fluxoperator.models.commands.Commands(
+                                pre="",
+                                run_flux_as_root=True,
+                            ),
+                            cores=56,
+                            diagnostics=True,
+                            environment={"key": ""},
+                            flux_log_level=56,
+                            flux_option_flags="",
+                            flux_user=fluxoperator.models.flux_user.FluxUser(
+                                name="",
+                                uid=56,
+                            ),
+                            image="",
+                            image_pull_secret="",
+                            life_cycle=fluxoperator.models.life_cycle.LifeCycle(
+                                post_start_exec="",
+                            ),
+                            name="",
+                            ports=[56],
+                            pre_command="",
+                            pull_always=True,
+                            resources=fluxoperator.models.container_resources.ContainerResources(
+                                limits={"key": None},
+                                requests={"key": None},
+                            ),
+                            run_flux=True,
+                            volumes={
+                                "key": fluxoperator.models.container_volume.ContainerVolume(
+                                    path="",
+                                    read_only=True,
+                                )
+                            },
+                            working_dir="",
+                        )
+                    ],
+                    deadline_seconds=56,
+                    flux_restful=fluxoperator.models.flux_restful.FluxRestful(
+                        branch="",
+                        port=56,
+                        token="",
+                        username="",
+                    ),
+                    job_labels={"key": ""},
+                    logging=fluxoperator.models.logging_spec.LoggingSpec(
+                        debug=True,
+                        quiet=True,
+                        strict=True,
+                        timed=True,
+                    ),
+                    pod=fluxoperator.models.pod_spec.PodSpec(
+                        annotations={"key": ""},
+                        labels={"key": ""},
+                    ),
+                    size=56,
+                    tasks=56,
+                    users=[
                         fluxoperator.models.mini_cluster_user.MiniClusterUser(
-                            name = '', 
-                            password = '', )
-                        ], 
-                    volumes = {
-                        'key' : fluxoperator.models.mini_cluster_volume.MiniClusterVolume(
-                            capacity = '', 
-                            path = '', 
-                            secret = '', 
-                            secret_namespace = '', 
-                            storage_class = '', )
-                        }, ), 
-                status = fluxoperator.models.mini_cluster_status.MiniClusterStatus(
-                    conditions = [
-                        None
-                        ], 
-                    jobid = '', )
+                            name="",
+                            password="",
+                        )
+                    ],
+                    volumes={
+                        "key": fluxoperator.models.mini_cluster_volume.MiniClusterVolume(
+                            capacity="",
+                            path="",
+                            secret="",
+                            secret_namespace="",
+                            storage_class="",
+                        )
+                    },
+                ),
+                status=fluxoperator.models.mini_cluster_status.MiniClusterStatus(
+                    conditions=[None],
+                    jobid="",
+                ),
             )
-        else :
-            return MiniCluster(
-        )
+        else:
+            return MiniCluster()
 
     def testMiniCluster(self):
         """Test MiniCluster"""
         inst_req_only = self.make_instance(include_optional=False)
         inst_req_and_optional = self.make_instance(include_optional=True)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/sdk/python/v1alpha1/test/test_mini_cluster_container.py
+++ b/sdk/python/v1alpha1/test/test_mini_cluster_container.py
@@ -16,8 +16,11 @@ import unittest
 import datetime
 
 import fluxoperator
-from fluxoperator.models.mini_cluster_container import MiniClusterContainer  # noqa: E501
+from fluxoperator.models.mini_cluster_container import (
+    MiniClusterContainer,
+)  # noqa: E501
 from fluxoperator.rest import ApiException
+
 
 class TestMiniClusterContainer(unittest.TestCase):
     """MiniClusterContainer unit test stubs"""
@@ -30,60 +33,58 @@ class TestMiniClusterContainer(unittest.TestCase):
 
     def make_instance(self, include_optional):
         """Test MiniClusterContainer
-            include_option is a boolean, when False only required
-            params are included, when True both required and
-            optional params are included """
+        include_option is a boolean, when False only required
+        params are included, when True both required and
+        optional params are included"""
         # model = fluxoperator.models.mini_cluster_container.MiniClusterContainer()  # noqa: E501
-        if include_optional :
+        if include_optional:
             return MiniClusterContainer(
-                command = '', 
-                commands = fluxoperator.models.commands.Commands(
-                    pre = '', 
-                    run_flux_as_root = True, ), 
-                cores = 56, 
-                diagnostics = True, 
-                environment = {
-                    'key' : ''
-                    }, 
-                flux_log_level = 56, 
-                flux_option_flags = '', 
-                flux_user = fluxoperator.models.flux_user.FluxUser(
-                    name = '', 
-                    uid = 56, ), 
-                image = '', 
-                image_pull_secret = '', 
-                life_cycle = fluxoperator.models.life_cycle.LifeCycle(
-                    post_start_exec = '', ), 
-                name = '', 
-                ports = [
-                    56
-                    ], 
-                pre_command = '', 
-                pull_always = True, 
-                resources = fluxoperator.models.container_resources.ContainerResources(
-                    limits = {
-                        'key' : None
-                        }, 
-                    requests = {
-                        'key' : None
-                        }, ), 
-                run_flux = True, 
-                volumes = {
-                    'key' : fluxoperator.models.container_volume.ContainerVolume(
-                        path = '', 
-                        read_only = True, )
-                    }, 
-                working_dir = ''
+                command="",
+                commands=fluxoperator.models.commands.Commands(
+                    pre="",
+                    run_flux_as_root=True,
+                ),
+                cores=56,
+                diagnostics=True,
+                environment={"key": ""},
+                flux_log_level=56,
+                flux_option_flags="",
+                flux_user=fluxoperator.models.flux_user.FluxUser(
+                    name="",
+                    uid=56,
+                ),
+                image="",
+                image_pull_secret="",
+                life_cycle=fluxoperator.models.life_cycle.LifeCycle(
+                    post_start_exec="",
+                ),
+                name="",
+                ports=[56],
+                pre_command="",
+                pull_always=True,
+                resources=fluxoperator.models.container_resources.ContainerResources(
+                    limits={"key": None},
+                    requests={"key": None},
+                ),
+                run_flux=True,
+                volumes={
+                    "key": fluxoperator.models.container_volume.ContainerVolume(
+                        path="",
+                        read_only=True,
+                    )
+                },
+                working_dir="",
             )
-        else :
+        else:
             return MiniClusterContainer(
-                image = '',
-        )
+                image="",
+            )
 
     def testMiniClusterContainer(self):
         """Test MiniClusterContainer"""
         inst_req_only = self.make_instance(include_optional=False)
         inst_req_and_optional = self.make_instance(include_optional=True)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/sdk/python/v1alpha1/test/test_mini_cluster_list.py
+++ b/sdk/python/v1alpha1/test/test_mini_cluster_list.py
@@ -19,6 +19,7 @@ import fluxoperator
 from fluxoperator.models.mini_cluster_list import MiniClusterList  # noqa: E501
 from fluxoperator.rest import ApiException
 
+
 class TestMiniClusterList(unittest.TestCase):
     """MiniClusterList unit test stubs"""
 
@@ -30,204 +31,201 @@ class TestMiniClusterList(unittest.TestCase):
 
     def make_instance(self, include_optional):
         """Test MiniClusterList
-            include_option is a boolean, when False only required
-            params are included, when True both required and
-            optional params are included """
+        include_option is a boolean, when False only required
+        params are included, when True both required and
+        optional params are included"""
         # model = fluxoperator.models.mini_cluster_list.MiniClusterList()  # noqa: E501
-        if include_optional :
+        if include_optional:
             return MiniClusterList(
-                api_version = '', 
-                items = [
+                api_version="",
+                items=[
                     fluxoperator.models.mini_cluster.MiniCluster(
-                        api_version = '', 
-                        kind = '', 
-                        metadata = None, 
-                        spec = fluxoperator.models.mini_cluster_spec.MiniClusterSpec(
-                            cleanup = True, 
-                            containers = [
+                        api_version="",
+                        kind="",
+                        metadata=None,
+                        spec=fluxoperator.models.mini_cluster_spec.MiniClusterSpec(
+                            cleanup=True,
+                            containers=[
                                 fluxoperator.models.mini_cluster_container.MiniClusterContainer(
-                                    command = '', 
-                                    commands = fluxoperator.models.commands.Commands(
-                                        pre = '', 
-                                        run_flux_as_root = True, ), 
-                                    cores = 56, 
-                                    diagnostics = True, 
-                                    environment = {
-                                        'key' : ''
-                                        }, 
-                                    flux_log_level = 56, 
-                                    flux_option_flags = '', 
-                                    flux_user = fluxoperator.models.flux_user.FluxUser(
-                                        name = '', 
-                                        uid = 56, ), 
-                                    image = '', 
-                                    image_pull_secret = '', 
-                                    life_cycle = fluxoperator.models.life_cycle.LifeCycle(
-                                        post_start_exec = '', ), 
-                                    name = '', 
-                                    ports = [
-                                        56
-                                        ], 
-                                    pre_command = '', 
-                                    pull_always = True, 
-                                    resources = fluxoperator.models.container_resources.ContainerResources(
-                                        limits = {
-                                            'key' : None
-                                            }, 
-                                        requests = {
-                                            'key' : None
-                                            }, ), 
-                                    run_flux = True, 
-                                    volumes = {
-                                        'key' : fluxoperator.models.container_volume.ContainerVolume(
-                                            path = '', 
-                                            read_only = True, )
-                                        }, 
-                                    working_dir = '', )
-                                ], 
-                            deadline_seconds = 56, 
-                            flux_restful = fluxoperator.models.flux_restful.FluxRestful(
-                                branch = '', 
-                                port = 56, 
-                                token = '', 
-                                username = '', ), 
-                            job_labels = {
-                                'key' : ''
-                                }, 
-                            logging = fluxoperator.models.logging_spec.LoggingSpec(
-                                debug = True, 
-                                quiet = True, 
-                                strict = True, 
-                                timed = True, ), 
-                            pod = fluxoperator.models.pod_spec.PodSpec(
-                                annotations = {
-                                    'key' : ''
-                                    }, 
-                                labels = {
-                                    'key' : ''
-                                    }, ), 
-                            size = 56, 
-                            tasks = 56, 
-                            users = [
+                                    command="",
+                                    commands=fluxoperator.models.commands.Commands(
+                                        pre="",
+                                        run_flux_as_root=True,
+                                    ),
+                                    cores=56,
+                                    diagnostics=True,
+                                    environment={"key": ""},
+                                    flux_log_level=56,
+                                    flux_option_flags="",
+                                    flux_user=fluxoperator.models.flux_user.FluxUser(
+                                        name="",
+                                        uid=56,
+                                    ),
+                                    image="",
+                                    image_pull_secret="",
+                                    life_cycle=fluxoperator.models.life_cycle.LifeCycle(
+                                        post_start_exec="",
+                                    ),
+                                    name="",
+                                    ports=[56],
+                                    pre_command="",
+                                    pull_always=True,
+                                    resources=fluxoperator.models.container_resources.ContainerResources(
+                                        limits={"key": None},
+                                        requests={"key": None},
+                                    ),
+                                    run_flux=True,
+                                    volumes={
+                                        "key": fluxoperator.models.container_volume.ContainerVolume(
+                                            path="",
+                                            read_only=True,
+                                        )
+                                    },
+                                    working_dir="",
+                                )
+                            ],
+                            deadline_seconds=56,
+                            flux_restful=fluxoperator.models.flux_restful.FluxRestful(
+                                branch="",
+                                port=56,
+                                token="",
+                                username="",
+                            ),
+                            job_labels={"key": ""},
+                            logging=fluxoperator.models.logging_spec.LoggingSpec(
+                                debug=True,
+                                quiet=True,
+                                strict=True,
+                                timed=True,
+                            ),
+                            pod=fluxoperator.models.pod_spec.PodSpec(
+                                annotations={"key": ""},
+                                labels={"key": ""},
+                            ),
+                            size=56,
+                            tasks=56,
+                            users=[
                                 fluxoperator.models.mini_cluster_user.MiniClusterUser(
-                                    name = '', 
-                                    password = '', )
-                                ], 
-                            volumes = {
-                                'key' : fluxoperator.models.mini_cluster_volume.MiniClusterVolume(
-                                    capacity = '', 
-                                    path = '', 
-                                    secret = '', 
-                                    secret_namespace = '', 
-                                    storage_class = '', )
-                                }, ), 
-                        status = fluxoperator.models.mini_cluster_status.MiniClusterStatus(
-                            conditions = [
-                                None
-                                ], 
-                            jobid = '', ), )
-                    ], 
-                kind = '', 
-                metadata = None
+                                    name="",
+                                    password="",
+                                )
+                            ],
+                            volumes={
+                                "key": fluxoperator.models.mini_cluster_volume.MiniClusterVolume(
+                                    capacity="",
+                                    path="",
+                                    secret="",
+                                    secret_namespace="",
+                                    storage_class="",
+                                )
+                            },
+                        ),
+                        status=fluxoperator.models.mini_cluster_status.MiniClusterStatus(
+                            conditions=[None],
+                            jobid="",
+                        ),
+                    )
+                ],
+                kind="",
+                metadata=None,
             )
-        else :
+        else:
             return MiniClusterList(
-                items = [
+                items=[
                     fluxoperator.models.mini_cluster.MiniCluster(
-                        api_version = '', 
-                        kind = '', 
-                        metadata = None, 
-                        spec = fluxoperator.models.mini_cluster_spec.MiniClusterSpec(
-                            cleanup = True, 
-                            containers = [
+                        api_version="",
+                        kind="",
+                        metadata=None,
+                        spec=fluxoperator.models.mini_cluster_spec.MiniClusterSpec(
+                            cleanup=True,
+                            containers=[
                                 fluxoperator.models.mini_cluster_container.MiniClusterContainer(
-                                    command = '', 
-                                    commands = fluxoperator.models.commands.Commands(
-                                        pre = '', 
-                                        run_flux_as_root = True, ), 
-                                    cores = 56, 
-                                    diagnostics = True, 
-                                    environment = {
-                                        'key' : ''
-                                        }, 
-                                    flux_log_level = 56, 
-                                    flux_option_flags = '', 
-                                    flux_user = fluxoperator.models.flux_user.FluxUser(
-                                        name = '', 
-                                        uid = 56, ), 
-                                    image = '', 
-                                    image_pull_secret = '', 
-                                    life_cycle = fluxoperator.models.life_cycle.LifeCycle(
-                                        post_start_exec = '', ), 
-                                    name = '', 
-                                    ports = [
-                                        56
-                                        ], 
-                                    pre_command = '', 
-                                    pull_always = True, 
-                                    resources = fluxoperator.models.container_resources.ContainerResources(
-                                        limits = {
-                                            'key' : None
-                                            }, 
-                                        requests = {
-                                            'key' : None
-                                            }, ), 
-                                    run_flux = True, 
-                                    volumes = {
-                                        'key' : fluxoperator.models.container_volume.ContainerVolume(
-                                            path = '', 
-                                            read_only = True, )
-                                        }, 
-                                    working_dir = '', )
-                                ], 
-                            deadline_seconds = 56, 
-                            flux_restful = fluxoperator.models.flux_restful.FluxRestful(
-                                branch = '', 
-                                port = 56, 
-                                token = '', 
-                                username = '', ), 
-                            job_labels = {
-                                'key' : ''
-                                }, 
-                            logging = fluxoperator.models.logging_spec.LoggingSpec(
-                                debug = True, 
-                                quiet = True, 
-                                strict = True, 
-                                timed = True, ), 
-                            pod = fluxoperator.models.pod_spec.PodSpec(
-                                annotations = {
-                                    'key' : ''
-                                    }, 
-                                labels = {
-                                    'key' : ''
-                                    }, ), 
-                            size = 56, 
-                            tasks = 56, 
-                            users = [
+                                    command="",
+                                    commands=fluxoperator.models.commands.Commands(
+                                        pre="",
+                                        run_flux_as_root=True,
+                                    ),
+                                    cores=56,
+                                    diagnostics=True,
+                                    environment={"key": ""},
+                                    flux_log_level=56,
+                                    flux_option_flags="",
+                                    flux_user=fluxoperator.models.flux_user.FluxUser(
+                                        name="",
+                                        uid=56,
+                                    ),
+                                    image="",
+                                    image_pull_secret="",
+                                    life_cycle=fluxoperator.models.life_cycle.LifeCycle(
+                                        post_start_exec="",
+                                    ),
+                                    name="",
+                                    ports=[56],
+                                    pre_command="",
+                                    pull_always=True,
+                                    resources=fluxoperator.models.container_resources.ContainerResources(
+                                        limits={"key": None},
+                                        requests={"key": None},
+                                    ),
+                                    run_flux=True,
+                                    volumes={
+                                        "key": fluxoperator.models.container_volume.ContainerVolume(
+                                            path="",
+                                            read_only=True,
+                                        )
+                                    },
+                                    working_dir="",
+                                )
+                            ],
+                            deadline_seconds=56,
+                            flux_restful=fluxoperator.models.flux_restful.FluxRestful(
+                                branch="",
+                                port=56,
+                                token="",
+                                username="",
+                            ),
+                            job_labels={"key": ""},
+                            logging=fluxoperator.models.logging_spec.LoggingSpec(
+                                debug=True,
+                                quiet=True,
+                                strict=True,
+                                timed=True,
+                            ),
+                            pod=fluxoperator.models.pod_spec.PodSpec(
+                                annotations={"key": ""},
+                                labels={"key": ""},
+                            ),
+                            size=56,
+                            tasks=56,
+                            users=[
                                 fluxoperator.models.mini_cluster_user.MiniClusterUser(
-                                    name = '', 
-                                    password = '', )
-                                ], 
-                            volumes = {
-                                'key' : fluxoperator.models.mini_cluster_volume.MiniClusterVolume(
-                                    capacity = '', 
-                                    path = '', 
-                                    secret = '', 
-                                    secret_namespace = '', 
-                                    storage_class = '', )
-                                }, ), 
-                        status = fluxoperator.models.mini_cluster_status.MiniClusterStatus(
-                            conditions = [
-                                None
-                                ], 
-                            jobid = '', ), )
-                    ],
-        )
+                                    name="",
+                                    password="",
+                                )
+                            ],
+                            volumes={
+                                "key": fluxoperator.models.mini_cluster_volume.MiniClusterVolume(
+                                    capacity="",
+                                    path="",
+                                    secret="",
+                                    secret_namespace="",
+                                    storage_class="",
+                                )
+                            },
+                        ),
+                        status=fluxoperator.models.mini_cluster_status.MiniClusterStatus(
+                            conditions=[None],
+                            jobid="",
+                        ),
+                    )
+                ],
+            )
 
     def testMiniClusterList(self):
         """Test MiniClusterList"""
         inst_req_only = self.make_instance(include_optional=False)
         inst_req_and_optional = self.make_instance(include_optional=True)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/sdk/python/v1alpha1/test/test_mini_cluster_spec.py
+++ b/sdk/python/v1alpha1/test/test_mini_cluster_spec.py
@@ -19,6 +19,7 @@ import fluxoperator
 from fluxoperator.models.mini_cluster_spec import MiniClusterSpec  # noqa: E501
 from fluxoperator.rest import ApiException
 
+
 class TestMiniClusterSpec(unittest.TestCase):
     """MiniClusterSpec unit test stubs"""
 
@@ -30,149 +31,139 @@ class TestMiniClusterSpec(unittest.TestCase):
 
     def make_instance(self, include_optional):
         """Test MiniClusterSpec
-            include_option is a boolean, when False only required
-            params are included, when True both required and
-            optional params are included """
+        include_option is a boolean, when False only required
+        params are included, when True both required and
+        optional params are included"""
         # model = fluxoperator.models.mini_cluster_spec.MiniClusterSpec()  # noqa: E501
-        if include_optional :
+        if include_optional:
             return MiniClusterSpec(
-                cleanup = True, 
-                containers = [
+                cleanup=True,
+                containers=[
                     fluxoperator.models.mini_cluster_container.MiniClusterContainer(
-                        command = '', 
-                        commands = fluxoperator.models.commands.Commands(
-                            pre = '', 
-                            run_flux_as_root = True, ), 
-                        cores = 56, 
-                        diagnostics = True, 
-                        environment = {
-                            'key' : ''
-                            }, 
-                        flux_log_level = 56, 
-                        flux_option_flags = '', 
-                        flux_user = fluxoperator.models.flux_user.FluxUser(
-                            name = '', 
-                            uid = 56, ), 
-                        image = '', 
-                        image_pull_secret = '', 
-                        life_cycle = fluxoperator.models.life_cycle.LifeCycle(
-                            post_start_exec = '', ), 
-                        name = '', 
-                        ports = [
-                            56
-                            ], 
-                        pre_command = '', 
-                        pull_always = True, 
-                        resources = fluxoperator.models.container_resources.ContainerResources(
-                            limits = {
-                                'key' : None
-                                }, 
-                            requests = {
-                                'key' : None
-                                }, ), 
-                        run_flux = True, 
-                        volumes = {
-                            'key' : fluxoperator.models.container_volume.ContainerVolume(
-                                path = '', 
-                                read_only = True, )
-                            }, 
-                        working_dir = '', )
-                    ], 
-                deadline_seconds = 56, 
-                flux_restful = fluxoperator.models.flux_restful.FluxRestful(
-                    branch = '', 
-                    port = 56, 
-                    token = '', 
-                    username = '', ), 
-                job_labels = {
-                    'key' : ''
-                    }, 
-                logging = fluxoperator.models.logging_spec.LoggingSpec(
-                    debug = True, 
-                    quiet = True, 
-                    strict = True, 
-                    timed = True, ), 
-                pod = fluxoperator.models.pod_spec.PodSpec(
-                    annotations = {
-                        'key' : ''
-                        }, 
-                    labels = {
-                        'key' : ''
-                        }, 
-                    resources = {
-                        'key' : None
-                        }, ), 
-                size = 56, 
-                tasks = 56, 
-                users = [
+                        command="",
+                        commands=fluxoperator.models.commands.Commands(
+                            pre="",
+                            run_flux_as_root=True,
+                        ),
+                        cores=56,
+                        diagnostics=True,
+                        environment={"key": ""},
+                        flux_log_level=56,
+                        flux_option_flags="",
+                        flux_user=fluxoperator.models.flux_user.FluxUser(
+                            name="",
+                            uid=56,
+                        ),
+                        image="",
+                        image_pull_secret="",
+                        life_cycle=fluxoperator.models.life_cycle.LifeCycle(
+                            post_start_exec="",
+                        ),
+                        name="",
+                        ports=[56],
+                        pre_command="",
+                        pull_always=True,
+                        resources=fluxoperator.models.container_resources.ContainerResources(
+                            limits={"key": None},
+                            requests={"key": None},
+                        ),
+                        run_flux=True,
+                        volumes={
+                            "key": fluxoperator.models.container_volume.ContainerVolume(
+                                path="",
+                                read_only=True,
+                            )
+                        },
+                        working_dir="",
+                    )
+                ],
+                deadline_seconds=56,
+                flux_restful=fluxoperator.models.flux_restful.FluxRestful(
+                    branch="",
+                    port=56,
+                    token="",
+                    username="",
+                ),
+                job_labels={"key": ""},
+                logging=fluxoperator.models.logging_spec.LoggingSpec(
+                    debug=True,
+                    quiet=True,
+                    strict=True,
+                    timed=True,
+                ),
+                pod=fluxoperator.models.pod_spec.PodSpec(
+                    annotations={"key": ""},
+                    labels={"key": ""},
+                    resources={"key": None},
+                ),
+                size=56,
+                tasks=56,
+                users=[
                     fluxoperator.models.mini_cluster_user.MiniClusterUser(
-                        name = '', 
-                        password = '', )
-                    ], 
-                volumes = {
-                    'key' : fluxoperator.models.mini_cluster_volume.MiniClusterVolume(
-                        annotations = {
-                            'key' : ''
-                            }, 
-                        capacity = '', 
-                        labels = {
-                            'key' : ''
-                            }, 
-                        path = '', 
-                        secret = '', 
-                        secret_namespace = '', 
-                        storage_class = '', )
-                    }
+                        name="",
+                        password="",
+                    )
+                ],
+                volumes={
+                    "key": fluxoperator.models.mini_cluster_volume.MiniClusterVolume(
+                        annotations={"key": ""},
+                        capacity="",
+                        labels={"key": ""},
+                        path="",
+                        secret="",
+                        secret_namespace="",
+                        storage_class="",
+                    )
+                },
             )
-        else :
+        else:
             return MiniClusterSpec(
-                containers = [
+                containers=[
                     fluxoperator.models.mini_cluster_container.MiniClusterContainer(
-                        command = '', 
-                        commands = fluxoperator.models.commands.Commands(
-                            pre = '', 
-                            run_flux_as_root = True, ), 
-                        cores = 56, 
-                        diagnostics = True, 
-                        environment = {
-                            'key' : ''
-                            }, 
-                        flux_log_level = 56, 
-                        flux_option_flags = '', 
-                        flux_user = fluxoperator.models.flux_user.FluxUser(
-                            name = '', 
-                            uid = 56, ), 
-                        image = '', 
-                        image_pull_secret = '', 
-                        life_cycle = fluxoperator.models.life_cycle.LifeCycle(
-                            post_start_exec = '', ), 
-                        name = '', 
-                        ports = [
-                            56
-                            ], 
-                        pre_command = '', 
-                        pull_always = True, 
-                        resources = fluxoperator.models.container_resources.ContainerResources(
-                            limits = {
-                                'key' : None
-                                }, 
-                            requests = {
-                                'key' : None
-                                }, ), 
-                        run_flux = True, 
-                        volumes = {
-                            'key' : fluxoperator.models.container_volume.ContainerVolume(
-                                path = '', 
-                                read_only = True, )
-                            }, 
-                        working_dir = '', )
-                    ],
-        )
+                        command="",
+                        commands=fluxoperator.models.commands.Commands(
+                            pre="",
+                            run_flux_as_root=True,
+                        ),
+                        cores=56,
+                        diagnostics=True,
+                        environment={"key": ""},
+                        flux_log_level=56,
+                        flux_option_flags="",
+                        flux_user=fluxoperator.models.flux_user.FluxUser(
+                            name="",
+                            uid=56,
+                        ),
+                        image="",
+                        image_pull_secret="",
+                        life_cycle=fluxoperator.models.life_cycle.LifeCycle(
+                            post_start_exec="",
+                        ),
+                        name="",
+                        ports=[56],
+                        pre_command="",
+                        pull_always=True,
+                        resources=fluxoperator.models.container_resources.ContainerResources(
+                            limits={"key": None},
+                            requests={"key": None},
+                        ),
+                        run_flux=True,
+                        volumes={
+                            "key": fluxoperator.models.container_volume.ContainerVolume(
+                                path="",
+                                read_only=True,
+                            )
+                        },
+                        working_dir="",
+                    )
+                ],
+            )
 
     def testMiniClusterSpec(self):
         """Test MiniClusterSpec"""
         inst_req_only = self.make_instance(include_optional=False)
         inst_req_and_optional = self.make_instance(include_optional=True)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/sdk/python/v1alpha1/test/test_mini_cluster_status.py
+++ b/sdk/python/v1alpha1/test/test_mini_cluster_status.py
@@ -19,6 +19,7 @@ import fluxoperator
 from fluxoperator.models.mini_cluster_status import MiniClusterStatus  # noqa: E501
 from fluxoperator.rest import ApiException
 
+
 class TestMiniClusterStatus(unittest.TestCase):
     """MiniClusterStatus unit test stubs"""
 
@@ -30,26 +31,22 @@ class TestMiniClusterStatus(unittest.TestCase):
 
     def make_instance(self, include_optional):
         """Test MiniClusterStatus
-            include_option is a boolean, when False only required
-            params are included, when True both required and
-            optional params are included """
+        include_option is a boolean, when False only required
+        params are included, when True both required and
+        optional params are included"""
         # model = fluxoperator.models.mini_cluster_status.MiniClusterStatus()  # noqa: E501
-        if include_optional :
+        if include_optional:
+            return MiniClusterStatus(conditions=[None], jobid="")
+        else:
             return MiniClusterStatus(
-                conditions = [
-                    None
-                    ], 
-                jobid = ''
+                jobid="",
             )
-        else :
-            return MiniClusterStatus(
-                jobid = '',
-        )
 
     def testMiniClusterStatus(self):
         """Test MiniClusterStatus"""
         inst_req_only = self.make_instance(include_optional=False)
         inst_req_and_optional = self.make_instance(include_optional=True)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/sdk/python/v1alpha1/test/test_mini_cluster_user.py
+++ b/sdk/python/v1alpha1/test/test_mini_cluster_user.py
@@ -19,6 +19,7 @@ import fluxoperator
 from fluxoperator.models.mini_cluster_user import MiniClusterUser  # noqa: E501
 from fluxoperator.rest import ApiException
 
+
 class TestMiniClusterUser(unittest.TestCase):
     """MiniClusterUser unit test stubs"""
 
@@ -30,24 +31,22 @@ class TestMiniClusterUser(unittest.TestCase):
 
     def make_instance(self, include_optional):
         """Test MiniClusterUser
-            include_option is a boolean, when False only required
-            params are included, when True both required and
-            optional params are included """
+        include_option is a boolean, when False only required
+        params are included, when True both required and
+        optional params are included"""
         # model = fluxoperator.models.mini_cluster_user.MiniClusterUser()  # noqa: E501
-        if include_optional :
+        if include_optional:
+            return MiniClusterUser(name="", password="")
+        else:
             return MiniClusterUser(
-                name = '', 
-                password = ''
+                name="",
             )
-        else :
-            return MiniClusterUser(
-                name = '',
-        )
 
     def testMiniClusterUser(self):
         """Test MiniClusterUser"""
         inst_req_only = self.make_instance(include_optional=False)
         inst_req_and_optional = self.make_instance(include_optional=True)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/sdk/python/v1alpha1/test/test_mini_cluster_volume.py
+++ b/sdk/python/v1alpha1/test/test_mini_cluster_volume.py
@@ -19,6 +19,7 @@ import fluxoperator
 from fluxoperator.models.mini_cluster_volume import MiniClusterVolume  # noqa: E501
 from fluxoperator.rest import ApiException
 
+
 class TestMiniClusterVolume(unittest.TestCase):
     """MiniClusterVolume unit test stubs"""
 
@@ -30,33 +31,30 @@ class TestMiniClusterVolume(unittest.TestCase):
 
     def make_instance(self, include_optional):
         """Test MiniClusterVolume
-            include_option is a boolean, when False only required
-            params are included, when True both required and
-            optional params are included """
+        include_option is a boolean, when False only required
+        params are included, when True both required and
+        optional params are included"""
         # model = fluxoperator.models.mini_cluster_volume.MiniClusterVolume()  # noqa: E501
-        if include_optional :
+        if include_optional:
             return MiniClusterVolume(
-                annotations = {
-                    'key' : ''
-                    }, 
-                capacity = '', 
-                labels = {
-                    'key' : ''
-                    }, 
-                path = '', 
-                secret = '', 
-                secret_namespace = '', 
-                storage_class = ''
+                annotations={"key": ""},
+                capacity="",
+                labels={"key": ""},
+                path="",
+                secret="",
+                secret_namespace="",
+                storage_class="",
             )
-        else :
+        else:
             return MiniClusterVolume(
-                path = '',
-        )
+                path="",
+            )
 
     def testMiniClusterVolume(self):
         """Test MiniClusterVolume"""
         inst_req_only = self.make_instance(include_optional=False)
         inst_req_and_optional = self.make_instance(include_optional=True)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/sdk/python/v1alpha1/test/test_pod_spec.py
+++ b/sdk/python/v1alpha1/test/test_pod_spec.py
@@ -19,6 +19,7 @@ import fluxoperator
 from fluxoperator.models.pod_spec import PodSpec  # noqa: E501
 from fluxoperator.rest import ApiException
 
+
 class TestPodSpec(unittest.TestCase):
     """PodSpec unit test stubs"""
 
@@ -30,30 +31,22 @@ class TestPodSpec(unittest.TestCase):
 
     def make_instance(self, include_optional):
         """Test PodSpec
-            include_option is a boolean, when False only required
-            params are included, when True both required and
-            optional params are included """
+        include_option is a boolean, when False only required
+        params are included, when True both required and
+        optional params are included"""
         # model = fluxoperator.models.pod_spec.PodSpec()  # noqa: E501
-        if include_optional :
+        if include_optional:
             return PodSpec(
-                annotations = {
-                    'key' : ''
-                    }, 
-                labels = {
-                    'key' : ''
-                    }, 
-                resources = {
-                    'key' : None
-                    }
+                annotations={"key": ""}, labels={"key": ""}, resources={"key": None}
             )
-        else :
-            return PodSpec(
-        )
+        else:
+            return PodSpec()
 
     def testPodSpec(self):
         """Test PodSpec"""
         inst_req_only = self.make_instance(include_optional=False)
         inst_req_and_optional = self.make_instance(include_optional=True)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
If we want tight control of time (and a consistent way to time between users) the Flux Operator Python SDK should be able to hold basic times for bringing the minicluster up (to when all pods are completed or ready) along with deletion and waiting for the restful API service. 