### PR TITLE
adding laghos simulation

### DIFF
--- a/examples/simulations/laghos-demos/minicluster.yaml
+++ b/examples/simulations/laghos-demos/minicluster.yaml
@@ -1,0 +1,31 @@
+apiVersion: flux-framework.org/v1alpha1
+kind: MiniCluster
+metadata:
+  name: flux-sample
+  namespace: flux-operator
+spec:
+  # Number of pods to create for MiniCluster
+  size: 4
+
+  # suppress all output except for test run
+  logging:
+    quiet: true
+    strict: false
+
+  # kubectl apply -f ./examples/simulations/laghos-demos/minicluster.yaml
+  # Then watch logs of the broker pod: kubectl logs -n flux-operator <pod> -f
+  containers:
+    - image: ghcr.io/rse-ops/laghos-demos:tag-mamba
+      cores: 2
+
+      # Note that you can also set launcher to true, and the command to "make tests"
+      # so that mpirun is given directly to flux start
+      # launcher: true
+
+      # Flux user has a different name
+      fluxUser:
+        name: fluxuser
+
+      # You can set the working directory if your container WORKDIR is not correct.
+      workingDir: /workflow/Laghos
+      command: ./laghos -p 0 -dim 2 -rs 3 -tf 0.75 -pa -vs 100


### PR DESCRIPTION
I looked at `make tests` and saw it was just running laghos, but with mpi run, so there are two ways of doing this:

- Give that command to flux submit to handle instead (in the PR here)
- Set the minicluster.yaml container to be a launcher, and still launch with mpirun and `make tests` (probably not what we want).

I found in practice the first was fast, and the second was much slower, maybe because it wasn't using all the resources available. Anyway, someone much smarter than me can fuddle with the parameters - this should get us started.

![image](https://user-images.githubusercontent.com/814322/226512100-481f3083-6d21-44aa-b103-dafc759e7603.png)
