### PR TITLE
add basic sundials example

### DIFF
--- a/examples/simulations/sundials/minicluster.yaml
+++ b/examples/simulations/sundials/minicluster.yaml
@@ -1,0 +1,48 @@
+apiVersion: flux-framework.org/v1alpha1
+kind: MiniCluster
+metadata:
+  name: flux-sample
+  namespace: flux-operator
+spec:
+  # Number of pods to create for MiniCluster
+  size: 4
+
+  # Make this kind of persistent volume and claim available to pods
+  # This is a path in minikube (e.g., minikube ssh)
+  volumes:
+    data:
+      storageClass: hostpath
+      path: /tmp/workflow
+
+  containers:
+    # The container URI to pull (currently needs to be public)
+    - image: ghcr.io/rse-ops/singularity:tag-mamba
+      cores: 4
+
+      # There are many examples in the environment but they segfault
+      # We would also need to source the spack environment, likely in a script
+      # And environment would need to write to somewhere writable!
+      # . /opt/spack/share/spack/setup-env.sh
+      # spack env activate sunenv
+      command: singularity exec --pwd /opt/spack/var/spack/environments/sunenv/.spack-env/view/examples/sunmatrix/dense ./sundials.sif ./test_sunmatrix_dense 10000 10000 1
+      workingDir: /data
+
+      # This pulls the container (once) by the broker to workingDir /data
+      commands:
+        pre: spack env load sunenv
+        brokerPre: |
+           if [[ ! -e "sundials.sif" ]]; then
+               singularity pull /data/sundials.sif docker://ghcr.io/rse-ops/sundials:tag-latest
+           fi
+
+      fluxUser:
+        name: fluxuser
+
+      # Container will be pre-pulled here only by the broker
+      volumes:
+        data:
+          path: /data
+       
+      # Running a container in a container
+      securityContext:
+        privileged: true


### PR DESCRIPTION
Likely to get the more complex examples working we will want to bind the mpi libraries to the host, OR build a container with sundials installed alongside flux to avoid singularity. Neither approach is the best, but for now this is a simple example that demonstrates it can work.