### PR TITLE
add tensorflow training example

### DIFF
--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -20,9 +20,12 @@ The following tutorials are provided from their respective directories (and are 
 
  - [Parsl](https://github.com/flux-framework/flux-operator/tree/main/examples/launchers/parsl)
 
-### Services and Machine Learning
+### Machine Learning
 
  - [Tensorflow cifar-10](https://github.com/flux-framework/flux-operator/blob/main/examples/machine-learning/tensorflow)
+
+### Services
+
  - [Merlin Basic](https://github.com/flux-framework/flux-operator/blob/main/examples/launchers/merlin/basic)
  - [Merlin Singularity Openfoam](https://github.com/flux-framework/flux-operator/blob/main/examples/launchers/merlin/singularity-openfoam)
 

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -20,11 +20,11 @@ The following tutorials are provided from their respective directories (and are 
 
  - [Parsl](https://github.com/flux-framework/flux-operator/tree/main/examples/launchers/parsl)
 
-### Services
+### Services and Machine Learning
 
+ - [Tensorflow cifar-10](https://github.com/flux-framework/flux-operator/blob/main/examples/machine-learning/tensorflow)
  - [Merlin Basic](https://github.com/flux-framework/flux-operator/blob/main/examples/launchers/merlin/basic)
  - [Merlin Singularity Openfoam](https://github.com/flux-framework/flux-operator/blob/main/examples/launchers/merlin/singularity-openfoam)
-
 
 ## Integrated Tutorials
 

--- a/examples/machine-learning/tensorflow/README.md
+++ b/examples/machine-learning/tensorflow/README.md
@@ -1,0 +1,52 @@
+# Tensorflow with Flux
+
+This is an experiment to distribute tensorflow jobs on a Flux Operator minicluster. We are
+basically going to try to match a distributed Tensorflow setup to the minicluster size, etc.
+
+> Tensorflow, Tensornooooo!
+
+I know, I know. But it's a fairly popular library. I promise it's worth a try!
+
+## Usage
+
+First, let's create a kind cluster. From the context of this directory:
+
+```bash
+$ kind create cluster --config ../../kind-config.yaml
+```
+
+And then install the operator, create the namespace, and apply the MiniCluster YAML here.
+
+```bash
+$ kubectl apply -f ../../dist/flux-operator.yaml
+$ kubectl create namespace flux-operator
+$ kubectl apply ./minicluster.yaml
+```
+
+## Example
+
+A complete usage example using the CIFAR-10 dataset is included in the examples directory,
+and this is what the minicluster is going to run! We basically launch main.py with flux,
+and we create a distributed Server via Flux, so a flux node running the script will take
+on a worker or "main" node task depending on the hostname. Note that the example original epochs
+were 1000, and I reduced to 10 to make it feasible to run. If you want to create your own
+distributed training using this:
+
+```python
+import tensorflow as tf
+from tensorflow_flux import tf_config_from_flux
+
+# Adjust your minicluster parameters here!
+cluster, my_job_name, my_task_index = tf_config_from_flux(
+    ps_number=1, cluster_size=4, job_name="flux-sample", port_number=2222
+)
+
+cluster_spec = tf.train.ClusterSpec(cluster)
+server = tf.distribute.Server(
+    server_or_cluster_def=cluster_spec,
+    job_name=my_job_name,
+    task_index=my_task_index
+)
+
+# Your code here
+```

--- a/examples/machine-learning/tensorflow/README.md
+++ b/examples/machine-learning/tensorflow/README.md
@@ -23,6 +23,34 @@ $ kubectl create namespace flux-operator
 $ kubectl apply ./minicluster.yaml
 ```
 
+You can then inspect logs, and see the training happening! Note that we adjusted 1000 epochs (takes a long time)
+to 2 (is very quick)!
+
+```bash
+$ kubectl logs -n flux-operator flux-sample-0-7tx7s -f
+```
+```console
+208 2 1.3872336 0.515625
+209 0 1.3110054 0.5625
+209 1 1.2829641 0.5234375
+209 2 1.496664 0.4296875
+210 1 1.3997178 0.4375
+210 0 1.4337707 0.484375
+210 2 1.2814229 0.5703125
+211 0 1.2377738 0.5078125
+211 1 1.497496 0.515625
+211 2 1.2085061 0.5625
+212 1 1.4642732 0.484375
+212 2 1.2024314 0.5859375
+212 0 1.6061184 0.453125
+...
+```
+
+In the above, you are looking at a row of `step task_number loss accuracy` where the task number corresponds
+to different flux cluster nodes. 2 epochs likely isn't enough to get a good result, but this is just an example.
+It's intended to get you started. If you have a tensorflow example to share,
+we hope you [let us know](https://github.com/flux-framework/flux-operator/issues).
+
 ## Example
 
 A complete usage example using the CIFAR-10 dataset is included in the examples directory,

--- a/examples/machine-learning/tensorflow/examples/cifar-10/download_data.sh
+++ b/examples/machine-learning/tensorflow/examples/cifar-10/download_data.sh
@@ -1,0 +1,6 @@
+#! /bin/bash
+
+if [[ ! -f "cifar-10-python.tar.gz" ]]; then
+    wget https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz .
+    tar -xvzf cifar-10-python.tar.gz
+fi

--- a/examples/machine-learning/tensorflow/examples/cifar-10/main.py
+++ b/examples/machine-learning/tensorflow/examples/cifar-10/main.py
@@ -4,6 +4,9 @@ from __future__ import division
 
 import pickle
 import os
+
+# We have v2 installed, but the cifar-10 example
+# was (I think) developed with v1 in mind, so I did this
 import tensorflow.compat.v1 as tf
 
 tf.disable_v2_behavior()
@@ -13,13 +16,14 @@ import sys
 from tensorflow_flux import tf_config_from_flux
 
 # ** Modify parameters here for your Minicluster **
+# ps number is the number of parameter servers to run. The rest are workers
 cluster, my_job_name, my_task_index = tf_config_from_flux(
     ps_number=1, cluster_size=4, job_name="flux-sample", port_number=2222
 )
 
 # original epochs was 1000, would take a few hours!
-# I adjusted to 10
-epochs = 10
+# I adjusted to 2, because we have things to do! :)
+epochs = 2
 
 cluster_spec = tf.train.ClusterSpec(cluster)
 server = tf.distribute.Server(

--- a/examples/machine-learning/tensorflow/examples/cifar-10/main.py
+++ b/examples/machine-learning/tensorflow/examples/cifar-10/main.py
@@ -1,0 +1,175 @@
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
+
+import pickle
+import os
+import tensorflow.compat.v1 as tf
+
+tf.disable_v2_behavior()
+
+import numpy as np
+import sys
+from tensorflow_flux import tf_config_from_flux
+
+# ** Modify parameters here for your Minicluster **
+cluster, my_job_name, my_task_index = tf_config_from_flux(
+    ps_number=1, cluster_size=4, job_name="flux-sample", port_number=2222
+)
+
+# original epochs was 1000, would take a few hours!
+# I adjusted to 10
+epochs = 10
+
+cluster_spec = tf.train.ClusterSpec(cluster)
+server = tf.distribute.Server(
+    server_or_cluster_def=cluster_spec, job_name=my_job_name, task_index=my_task_index
+)
+
+if my_job_name == "ps":
+    server.join()
+    sys.exit(0)
+
+data_dir = "cifar-10-batches-py"
+filelist = [
+    os.path.join(data_dir, "data_batch_1"),
+    os.path.join(data_dir, "data_batch_2"),
+    os.path.join(data_dir, "data_batch_3"),
+    os.path.join(data_dir, "data_batch_4"),
+    os.path.join(data_dir, "data_batch_5"),
+]
+
+data, labels = [], []
+is_chief = my_task_index == 0
+
+
+def unpickle(file):
+    with open(file, "rb") as fo:
+        obj = pickle.load(fo, encoding="bytes")
+    return obj
+
+
+for f in filelist:
+    data_elem = unpickle(f)
+    data.append(data_elem[b"data"])
+    labels.extend(data_elem[b"labels"])
+data = np.vstack(d for d in data)
+print("data shape: ", data.shape)
+
+
+def weight_variable(shape):
+    with tf.device("/job:ps/task:0"):
+        initial = tf.truncated_normal(shape, stddev=0.1)
+        v = tf.Variable(initial)
+        return v
+
+
+def bias_variable(shape):
+    with tf.device("/job:ps/task:0"):
+        initial = tf.constant(0.1, shape=shape)
+        v = tf.Variable(initial)
+        return v
+
+
+def conv2d(x, W):
+    return tf.nn.conv2d(x, W, strides=[1, 1, 1, 1], padding="VALID")
+
+
+def max_pool_2x2(x):
+    return tf.nn.max_pool(x, ksize=[1, 2, 2, 1], strides=[1, 2, 2, 1], padding="SAME")
+
+
+with tf.device("/job:worker/task:{}".format(my_task_index)):
+    x = tf.placeholder(tf.float32, shape=[None, 3072], name="x")
+    y = tf.placeholder(tf.uint8, shape=[None, 1], name="y")
+
+    # FIRST CONVOLUTIONAL LAYER
+    y_one_hot = tf.one_hot(indices=y, depth=10)
+
+    ks = 5
+    n_filters1 = 16
+    W_conv1 = weight_variable([ks, ks, 3, n_filters1])
+    b_conv1 = bias_variable([n_filters1])
+
+    reshaped = tf.reshape(x, [-1, 3, 32, 32])
+    transposed = tf.transpose(reshaped, [0, 2, 3, 1])
+    x_image = (transposed - 128) / 128
+
+    h_conv1 = tf.nn.relu(conv2d(x_image, W_conv1) + b_conv1)
+    h_pool1 = max_pool_2x2(h_conv1)
+
+    # SECOND CONVOLUTIONAL LAYER
+    n_filters2 = 64
+    W_conv2 = weight_variable([ks, ks, n_filters1, n_filters2])
+    b_conv2 = bias_variable([n_filters2])
+
+    h_conv2 = tf.nn.relu(conv2d(h_pool1, W_conv2) + b_conv2)
+    h_pool2 = max_pool_2x2(h_conv2)
+
+    # FULLY CONNECTED LAYER
+    hidden_neurons = 512
+    W_fc1 = weight_variable([5 * 5 * n_filters2, hidden_neurons])
+    b_fc1 = bias_variable([hidden_neurons])
+
+    h_pool2_flat = tf.reshape(h_pool2, [-1, 5 * 5 * n_filters2])
+    h_fc1 = tf.nn.relu(tf.matmul(h_pool2_flat, W_fc1) + b_fc1)
+
+    # DROPOUT
+    keep_prob = tf.placeholder(tf.float32)
+    h_fc1_drop = tf.nn.dropout(h_fc1, keep_prob)
+
+    # SOFTMAX
+    W_fc2 = weight_variable([hidden_neurons, 10])
+    b_fc2 = bias_variable([10])
+
+    y_conv = tf.matmul(h_fc1_drop, W_fc2) + b_fc2
+    cross_entropy = tf.nn.softmax_cross_entropy_with_logits(
+        logits=y_conv, labels=y_one_hot
+    )
+    loss = tf.reduce_mean(cross_entropy)
+    opt = tf.train.AdamOptimizer(1e-3)
+    opt = tf.train.SyncReplicasOptimizer(
+        opt,
+        replicas_to_aggregate=len(cluster["worker"]),
+        total_num_replicas=len(cluster["worker"]),
+    )
+    global_step = bias_variable([])
+    train_step = opt.minimize(loss, global_step=global_step)
+    sync_replicas_hook = opt.make_session_run_hook(is_chief)
+
+    y_hat = tf.round(tf.argmax(tf.nn.softmax(y_conv), 1))
+    y_hat = tf.cast(y_hat, tf.uint8)
+    y_hat = tf.reshape(y_hat, [-1, 1])
+    correct_prediction = tf.equal(y_hat, y)
+    accuracy = tf.reduce_mean(tf.cast(correct_prediction, tf.float32))
+
+
+def batch_generator(data, labels, batch_size=32):
+    x_batch, y_batch = [], []
+    for d, l in zip(data, labels):
+        x_batch.append(d)
+        y_batch.append(l)
+        if len(x_batch) == batch_size:
+            yield np.vstack(x_batch), np.vstack(y_batch)
+            x_batch = []
+            y_batch = []
+
+
+batch_size = 128
+step = 0
+sess = tf.train.MonitoredTrainingSession(
+    master=server.target, is_chief=is_chief, hooks=[sync_replicas_hook]
+)
+
+for i in range(epochs):
+    bg = batch_generator(data, labels, batch_size)
+    for j, (data_batch, label_batch) in enumerate(bg):
+        if (j + i) % len(cluster["worker"]) != my_task_index:
+            continue
+        _, loss_, acc = sess.run(
+            [train_step, loss, accuracy],
+            feed_dict={x: data_batch, y: label_batch.reshape(-1, 1), keep_prob: 0.5},
+        )
+        step += 1
+        print(step, my_task_index, loss_, acc)
+        sys.stdout.flush()

--- a/examples/machine-learning/tensorflow/minicluster.yaml
+++ b/examples/machine-learning/tensorflow/minicluster.yaml
@@ -4,6 +4,8 @@ metadata:
   name: flux-sample
   namespace: flux-operator
 spec:
+
+  # This ensures we launch the main script on all the nodes
   size: 4
   tasks: 4
   volumes:
@@ -13,36 +15,29 @@ spec:
 
   # This is a list because a pod can support multiple containers
   containers:
-    - image: ghcr.io/rse-ops/singularity:tag-mamba
+      # This has tensorflow 2.11.1
+    - image: ghcr.io/rse-ops/singularity-tensorflow:tag-mamba
       workingDir: /tmp/workflow/examples/cifar-10
       command: python3 ./main.py
 
-      # Where flux is
+      # Where is flux? There he is!
       environment:
         PYTHONPATH: /usr/lib/python3.10/site-packages
 
-      # Tensorflow 2.11.1 was used for this example
       commands:
         brokerPre: |
           cd /tmp/workflow
-          mamba install -y tensorflow ipython
           pip install .
           cd /tmp/workflow/examples/cifar-10
           ./download_data.sh          
         workerPre: |
           cd /tmp/workflow
-          mamba install -y tensorflow ipython
           pip install .
           cd -
           
       fluxUser:
         name: fluxuser
 
-      # Container will be pre-pulled here only by the broker
       volumes:
         data:
           path: /tmp/workflow
-       
-      # Running a container in a container
-      securityContext:
-        privileged: true

--- a/examples/machine-learning/tensorflow/minicluster.yaml
+++ b/examples/machine-learning/tensorflow/minicluster.yaml
@@ -1,0 +1,48 @@
+apiVersion: flux-framework.org/v1alpha1
+kind: MiniCluster
+metadata:
+  name: flux-sample
+  namespace: flux-operator
+spec:
+  size: 4
+  tasks: 4
+  volumes:
+    data:
+      storageClass: hostpath
+      path: /tmp/workflow
+
+  # This is a list because a pod can support multiple containers
+  containers:
+    - image: ghcr.io/rse-ops/singularity:tag-mamba
+      workingDir: /tmp/workflow/examples/cifar-10
+      command: python3 ./main.py
+
+      # Where flux is
+      environment:
+        PYTHONPATH: /usr/lib/python3.10/site-packages
+
+      # Tensorflow 2.11.1 was used for this example
+      commands:
+        brokerPre: |
+          cd /tmp/workflow
+          mamba install -y tensorflow ipython
+          pip install .
+          cd /tmp/workflow/examples/cifar-10
+          ./download_data.sh          
+        workerPre: |
+          cd /tmp/workflow
+          mamba install -y tensorflow ipython
+          pip install .
+          cd -
+          
+      fluxUser:
+        name: fluxuser
+
+      # Container will be pre-pulled here only by the broker
+      volumes:
+        data:
+          path: /tmp/workflow
+       
+      # Running a container in a container
+      securityContext:
+        privileged: true

--- a/examples/machine-learning/tensorflow/setup.py
+++ b/examples/machine-learning/tensorflow/setup.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+from distutils.core import setup
+
+setup(
+    name="tensorflow_flux",
+    version="0.1.0",
+    description="Run distributed TensorFlow on the Flux Operator",
+    author="Vanessasaurus",
+    author_email="sochat1@llnl.gov",
+    url="https://github.com/flux-framework/flux-operator/tree/main/examples/machine-learning/tensorflow",
+    packages=["tensorflow_flux"],
+)

--- a/examples/machine-learning/tensorflow/tensorflow_flux/__init__.py
+++ b/examples/machine-learning/tensorflow/tensorflow_flux/__init__.py
@@ -1,0 +1,3 @@
+from .tensorflow_flux import tf_config_from_flux
+
+__all__ = ['tf_config_from_flux']

--- a/examples/machine-learning/tensorflow/tensorflow_flux/tensorflow_flux.py
+++ b/examples/machine-learning/tensorflow/tensorflow_flux/tensorflow_flux.py
@@ -1,0 +1,47 @@
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
+
+import socket
+import os
+
+
+def tf_config_from_flux(ps_number, cluster_size=4, job_name="flux-sample", port_number=2222):
+    """
+    Creates configuration for a distributed tensorflow session 
+    from environment variables provided by the the Flux operator.
+    
+    @param: ps_number number of parameter servers to run
+    @param: job_name name of minicluster job
+    @param: cluster_size number of nodes in cluster
+    @param: port_number port number to be used for communication
+    @return: a tuple containing cluster with fields cluster_spec,
+             task_name and task_id 
+    """
+    # TODO this needs to be generalized for the cluster and number of workers.
+    # Environment variables would be OK
+    nodelist = os.environ.get("FLUX_JOB_NODELIST") or ["%s-%s.flux-service.flux-operator.svc.cluster.local" %(job_name, i) for i in range(cluster_size)]
+    nodename = os.environ.get("FLUX_NODENAME") or "%s.flux-service.flux-operator.svc.cluster.local" % socket.gethostname()
+    num_nodes = int(os.getenv("FLUX_NUM_NODES") or cluster_size)
+    
+    if len(nodelist) != num_nodes:
+        raise ValueError("Number of flux nodes {} not equal to {}".format(len(nodelist), num_nodes))
+    
+    if nodename not in nodelist:
+        raise ValueError("Nodename({}) not in nodelist({}). This should not happen! ".format(nodename,nodelist))
+    
+    ps_nodes = [node for i, node in enumerate(nodelist) if i < ps_number]
+    worker_nodes = [node for i, node in enumerate(nodelist) if i >= ps_number]
+    
+    if nodename in ps_nodes:
+        my_job_name = "ps"
+        my_task_index = ps_nodes.index(nodename)
+    else:
+        my_job_name = "worker"
+        my_task_index = worker_nodes.index(nodename)
+    
+    worker_sockets = [":".join([node, str(port_number)]) for node in worker_nodes]
+    ps_sockets = [":".join([node, str(port_number)]) for node in ps_nodes]
+    cluster = {"worker": worker_sockets, "ps" : ps_sockets}
+    
+    return cluster, my_job_name, my_task_index

--- a/examples/machine-learning/tensorflow/tensorflow_flux/tensorflow_flux.py
+++ b/examples/machine-learning/tensorflow/tensorflow_flux/tensorflow_flux.py
@@ -18,8 +18,6 @@ def tf_config_from_flux(ps_number, cluster_size=4, job_name="flux-sample", port_
     @return: a tuple containing cluster with fields cluster_spec,
              task_name and task_id 
     """
-    # TODO this needs to be generalized for the cluster and number of workers.
-    # Environment variables would be OK
     nodelist = os.environ.get("FLUX_JOB_NODELIST") or ["%s-%s.flux-service.flux-operator.svc.cluster.local" %(job_name, i) for i in range(cluster_size)]
     nodename = os.environ.get("FLUX_NODENAME") or "%s.flux-service.flux-operator.svc.cluster.local" % socket.gethostname()
     num_nodes = int(os.getenv("FLUX_NUM_NODES") or cluster_size)


### PR DESCRIPTION
This example creates a tensorflow.distributed.Server using flux nodes, where the broker is the "main" runner (not sure if there is a terminology for that) and the rest are workers. They each set up communication via RPC and then the main node is able to coordinate training across the workers. Since we run with flux and the number of workers, this is running under the flux instance provided by the job.

I'm uneasy about having the example install via mamba at runtime, so likely I'm going to build a container with tensorflow (at time of writing looks like it's using 2.11.1, but I am falling back to v1 compat) so at least we have a container that can reproduce the demo running!

Also note the original example for ciphar-10 had 1000 epochs, but I figured that would take a really long time and reduced to 10. Actually, the number of epochs might be an interesting variable to vary for some experiment? Even if we don't choose this particular training task?