### PR TITLE
Add/dask example scikit learn

### DIFF
--- a/controllers/flux/templates/wait.sh
+++ b/controllers/flux/templates/wait.sh
@@ -147,7 +147,7 @@ mkdir -p /etc/flux/system
 
 # --cores=IDS Assign cores with IDS to each rank in R, so we  assign 0-(N-1) to each host
 {{ if not .Spec.Logging.Quiet }}echo "flux R encode --hosts={{ .Hosts}} {{if .Cores}}--cores=0-{{.Cores}}{{ end }}"{{ end }}
-flux R encode --hosts={{ .Hosts}} {{if .Cores}}--cores=0-{{.Cores}}{{ end }} > /etc/flux/system/R
+flux R encode --hosts={{ .Hosts}} {{if .Cores}}--cores=0-{{.Cores}}{{ else }}--local{{ end }} > /etc/flux/system/R
 {{ if not .Spec.Logging.Quiet }}printf "\n📦 Resources\n"
 cat /etc/flux/system/R{{ end }}
 

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -25,6 +25,7 @@ The following tutorials are provided from their respective directories (and are 
  - [Fireworks](https://github.com/flux-framework/flux-operator/blob/main/examples/machine-learning/fireworks)
  - [Pytorch MNIST](https://github.com/flux-framework/flux-operator/blob/main/examples/machine-learning/pytorch)
  - [Tensorflow cifar-10](https://github.com/flux-framework/flux-operator/blob/main/examples/machine-learning/tensorflow)
+ - [Dask with Scikit-Learn](https://github.com/flux-framework/flux-operator/blob/main/examples/machine-learning/dask/scikit-learn)
 
 ### Services
 

--- a/examples/machine-learning/dask/scikit-learn/README.md
+++ b/examples/machine-learning/dask/scikit-learn/README.md
@@ -38,65 +38,56 @@ and parameters. You'll see this in the log (expand the section below):
 
 ```console
 ...
-broker.info[0]: rc1.0: running /etc/flux/rc1.d/01-sched-fluxion
-sched-fluxion-resource.info[0]: version 214aa27
-sched-fluxion-resource.warning[0]: create_reader: allowlist unsupported
-sched-fluxion-resource.info[0]: populate_resource_db: loaded resources from core's resource.acquire
-sched-fluxion-qmanager.info[0]: version 214aa27
-broker.info[0]: rc1.0: running /etc/flux/rc1.d/02-cron
-broker.info[0]: rc1.0: /etc/flux/rc1 Exited (rc=0) 3.8s
-broker.info[0]: rc1-success: init->quorum 3.8019s
-broker.info[0]: online: flux-sample-0 (ranks 0)
-broker.info[0]: online: flux-sample-[0-3] (ranks 0-3)
-broker.info[0]: quorum-full: quorum->run 3.99891s
+broker.info[0]: quorum-full: quorum->run 8.10777s
      nodes: 4
      cores: 2
    timeout: 60
 Fitting model...
 Fitting 3 folds for each of 50 candidates, totalling 150 fits
 CV Results:
-{'mean_fit_time': array([4.08554602, 5.423575  , 3.39528402, 2.85911171, 4.831592  ,
-       3.88271205, 3.02563477, 2.47843599, 0.68565289, 2.93963766,
-       3.39221478, 3.79691935, 3.96530684, 3.82564553, 4.97321709,
-       3.84288883, 1.15530101, 1.35951893, 3.7286648 , 4.03004575,
-       3.66520365, 3.37004209, 3.13437613, 2.99476473, 2.26174323,
-       3.39319603, 2.89181201, 2.62760369, 0.65904252, 0.39908274,
-       3.00021768, 0.34174371, 3.26659242, 3.26887321, 3.08342997,
-       2.61445681, 3.21243397, 3.22617459, 3.29642828, 2.41557391,
-       3.36702911, 3.24384109, 2.87103478, 2.92750065, 0.34344927,
-       0.5176696 , 2.61106515, 0.41769854, 0.67651065, 0.86017307]), 'std_fit_time': array([1.29295808, 0.44993044, 1.13105463, 0.24890695, 1.53956746,
-       0.93328344, 0.66994432, 0.16029377, 0.17592682, 0.12820939,
-       0.37487107, 0.68207106, 0.36123274, 0.27662093, 0.44998325,
-       0.11232528, 0.15331819, 0.29612327, 0.23260674, 0.20277183,
-       0.10520431, 0.34012566, 0.15273326, 0.25142427, 0.26527932,
-       0.10249256, 0.11939426, 0.40004664, 0.02033139, 0.06673623,
-       0.05008267, 0.05227693, 0.29535088, 0.14343989, 0.26508654,
-       0.20566045, 0.40562526, 0.30273003, 0.62674814, 0.09708462,
-       0.41936624, 0.34741114, 0.15964411, 0.2086272 , 0.04933951,
-       0.01189969, 0.22959803, 0.08866899, 0.05076011, 0.12571382]), 'mean_score_time': array([2.26498397, 1.77561784, 1.6284159 , 2.33371989, 1.4934899 ,
-       1.65991545, 1.01165613, 1.26928711, 0.80194203, 1.01934727,
-       1.14952954, 1.31477968, 2.05600015, 1.86737108, 1.60693971,
-       1.95683328, 0.96571255, 1.25838002, 0.99948716, 1.46727578,
-       0.9671642 , 1.23076653, 1.0414288 , 1.23779511, 1.16715463,
-       1.123487  , 0.96316584, 1.07391651, 0.62996387, 0.42405613,
-       1.30649598, 0.31687458, 1.05327328, 1.01003925, 1.0420777 ,
-       0.98385247, 1.26904154, 1.24301561, 1.3658274 , 1.24738073,
-       1.36005807, 1.32252598, 1.04261764, 1.03164657, 0.29092725,
-       0.48727504, 0.32448387, 0.60944939, 0.42013979, 0.33401561]), 'std_score_time': array([0.20775316, 0.24286407, 0.11926821, 0.40169773, 0.55680183,
-       0.78485425, 0.17111927, 0.06430806, 0.1293463 , 0.23254882,
-       0.26622301, 0.2448651 , 0.21866524, 0.3043432 , 0.11532111,
-       0.35099115, 0.02410389, 0.02678309, 0.2368529 , 0.13744223,
-       0.1707387 , 0.17363425, 0.07558077, 0.02828425, 0.04064274,
-       0.07727504, 0.03594565, 0.03109774, 0.16673041, 0.12429896,
-       0.26720998, 0.06015071, 0.24929352, 0.15515904, 0.10645853,
-       0.12264939, 0.19762409, 0.29526357, 0.08137586, 0.23999344,
-       0.21649012, 0.16955293, 0.10475885, 0.22040064, 0.07748718,
-       0.02336777, 0.0849569 , 0.20914747, 0.09983006, 0.12743123]), 'param_tol': masked_array(data=[0.0001, 0.0001, 0.01, 0.1, 0.0001, 0.1, 0.001, 0.1,
-                   0.1, 0.1, 0.01, 0.0001, 0.01, 0.1, 0.0001, 0.1, 0.0001,
-                   0.01, 0.0001, 0.1, 0.01, 0.1, 0.001, 0.1, 0.01, 0.0001,
-                   0.01, 0.001, 0.01, 0.01, 0.0001, 0.1, 0.01, 0.1, 0.001,
-                   0.001, 0.1, 0.01, 0.0001, 0.01, 0.001, 0.01, 0.1,
-                   0.0001, 0.01, 0.0001, 0.1, 0.01, 0.0001, 0.001],
+{'mean_fit_time': array([0.15570553, 0.51860126, 0.19759989, 0.64971646, 1.11043668,
+       0.70452181, 0.45543218, 0.65649104, 0.18509126, 0.83856575,
+       0.5343864 , 0.10854268, 0.48223329, 0.58255227, 0.90180922,
+       0.58144879, 0.43473721, 0.50423455, 0.56936741, 0.71839229,
+       0.57419117, 0.63295786, 0.70854092, 0.44340865, 0.63092494,
+       0.52340007, 0.18849103, 0.63563204, 0.51590824, 0.70667044,
+       0.21578566, 1.60080806, 1.33359655, 1.10012269, 1.40437373,
+       1.2077709 , 1.61136468, 0.96858056, 0.77815445, 1.86761228,
+       1.17164087, 0.82484341, 1.44043525, 0.62390828, 0.1474026 ,
+       0.68102757, 0.78141077, 1.01250768, 0.17216452, 0.16020226]), 'std_fit_time': array([0.05973971, 0.02064363, 0.11392156, 0.20227573, 0.23869862,
+       0.12768428, 0.26120387, 0.13420861, 0.12622454, 0.34138889,
+       0.15459305, 0.03619015, 0.24097666, 0.11489993, 0.38121573,
+       0.39901444, 0.08708329, 0.09285345, 0.1375759 , 0.30515549,
+       0.03026783, 0.38156088, 0.27626739, 0.07518921, 0.20766368,
+       0.09118748, 0.04499471, 0.14277432, 0.25293918, 0.16685543,
+       0.16787551, 0.46418934, 0.49988848, 0.33567834, 0.22331225,
+       0.4063815 , 0.96429528, 0.28826377, 0.07038422, 0.79501514,
+       0.22408482, 0.3940187 , 0.58454422, 0.30810265, 0.04627154,
+       0.14212024, 0.2327521 , 0.25167742, 0.03180488, 0.05622747]), 'mean_score_time': array([0.12284168, 0.24133762, 0.14054163, 0.34191608, 0.39344056,
+       0.15338906, 0.2731572 , 0.17744438, 0.08095241, 0.30493943,
+       0.21205497, 0.10514394, 0.1793685 , 0.18684332, 0.17610041,
+       0.28196398, 0.16805506, 0.17218431, 0.28246578, 0.33911284,
+       0.251134  , 0.2022237 , 0.19816089, 0.17895484, 0.24495657,
+       0.20406127, 0.0819521 , 0.23025791, 0.27222069, 0.17183677,
+       0.12053823, 0.48007766, 0.49195663, 0.60704327, 0.32456334,
+       0.4532942 , 0.38196683, 0.3058788 , 0.27657493, 0.52431941,
+       0.54452038, 0.42188247, 0.27936172, 0.18626753, 0.07600037,
+       0.31255293, 0.1613245 , 0.10662246, 0.11645667, 0.07987253]), 'std_score_time': array([0.02947438, 0.13599553, 0.07094923, 0.17235629, 0.19668163,
+       0.04341179, 0.12056547, 0.04881971, 0.05108642, 0.13522542,
+       0.12704275, 0.05661904, 0.04277962, 0.05244728, 0.0627563 ,
+       0.15396325, 0.04543695, 0.03009697, 0.05424151, 0.20868148,
+       0.16283435, 0.01805788, 0.03947139, 0.01423403, 0.04341597,
+       0.06779754, 0.01885673, 0.0365029 , 0.02512524, 0.0089466 ,
+       0.05745425, 0.19493876, 0.07011112, 0.06704884, 0.09924098,
+       0.22260647, 0.14120678, 0.10279065, 0.09608677, 0.16628384,
+       0.26581479, 0.28444677, 0.08030146, 0.01928522, 0.01555274,
+       0.01898241, 0.0056812 , 0.03295954, 0.05005373, 0.02138194]), 'param_tol': masked_array(data=[0.0001, 0.1, 0.001, 0.001, 0.001, 0.1, 0.01, 0.001,
+                   0.0001, 0.0001, 0.1, 0.0001, 0.001, 0.0001, 0.1,
+                   0.0001, 0.01, 0.1, 0.01, 0.001, 0.01, 0.01, 0.001,
+                   0.001, 0.01, 0.0001, 0.001, 0.1, 0.001, 0.001, 0.01,
+                   0.01, 0.001, 0.01, 0.1, 0.01, 0.01, 0.0001, 0.0001,
+                   0.1, 0.1, 0.0001, 0.1, 0.001, 0.001, 0.0001, 0.1, 0.1,
+                   0.1, 0.1],
              mask=[False, False, False, False, False, False, False, False,
                    False, False, False, False, False, False, False, False,
                    False, False, False, False, False, False, False, False,
@@ -105,14 +96,14 @@ CV Results:
                    False, False, False, False, False, False, False, False,
                    False, False],
        fill_value='?',
-            dtype=object), 'param_gamma': masked_array(data=[10000.0, 1000.0, 100000.0, 0.01, 100000.0, 0.1, 1e-08,
-                   1000.0, 1e-05, 10.0, 0.0001, 0.1, 0.01, 1e-08,
-                   100000000.0, 10.0, 0.0001, 0.001, 1e-08, 0.001, 1e-07,
-                   100000000.0, 10000000.0, 100000.0, 100000.0, 1e-05,
-                   100.0, 100000.0, 1e-07, 0.0001, 100000.0, 1e-05,
-                   100000000.0, 1.0, 1.0, 10000.0, 0.1, 1.0, 10.0,
-                   100000.0, 0.01, 100.0, 100000.0, 100000.0, 1e-05,
-                   0.0001, 100.0, 0.0001, 1e-05, 1e-07],
+            dtype=object), 'param_gamma': masked_array(data=[1e-06, 1e-05, 0.0001, 100000.0, 0.1, 1e-06, 1e-05,
+                   10000000.0, 1e-06, 0.1, 100.0, 1e-06, 100.0, 10000.0,
+                   100.0, 1e-06, 10000000.0, 0.0001, 0.01, 1000000.0, 0.1,
+                   1000.0, 1e-06, 1e-08, 10000000.0, 1e-08, 0.001, 1000.0,
+                   1e-05, 0.001, 1e-06, 10.0, 1000.0, 10000.0, 100000.0,
+                   10000.0, 0.01, 100.0, 10000000.0, 1000000.0, 1.0,
+                   1000.0, 100000000.0, 100000.0, 1e-07, 1e-08, 1e-08,
+                   1e-08, 0.001, 0.001],
              mask=[False, False, False, False, False, False, False, False,
                    False, False, False, False, False, False, False, False,
                    False, False, False, False, False, False, False, False,
@@ -121,15 +112,15 @@ CV Results:
                    False, False, False, False, False, False, False, False,
                    False, False],
        fill_value='?',
-            dtype=object), 'param_class_weight': masked_array(data=['balanced', None, 'balanced', 'balanced', 'balanced',
-                   'balanced', None, None, 'balanced', 'balanced',
-                   'balanced', None, 'balanced', None, 'balanced', None,
-                   None, None, None, 'balanced', 'balanced', 'balanced',
-                   None, 'balanced', 'balanced', 'balanced', None, None,
-                   None, None, None, None, None, 'balanced', 'balanced',
-                   'balanced', None, 'balanced', None, None, 'balanced',
-                   None, None, 'balanced', None, 'balanced', None, None,
-                   'balanced', 'balanced'],
+            dtype=object), 'param_class_weight': masked_array(data=['balanced', None, 'balanced', None, None, None, None,
+                   None, None, 'balanced', None, 'balanced', 'balanced',
+                   None, None, 'balanced', None, None, None, 'balanced',
+                   'balanced', 'balanced', 'balanced', None, 'balanced',
+                   None, 'balanced', None, None, 'balanced', 'balanced',
+                   None, 'balanced', None, 'balanced', None, 'balanced',
+                   None, None, None, 'balanced', None, None, None,
+                   'balanced', None, 'balanced', 'balanced', 'balanced',
+                   None],
              mask=[False, False, False, False, False, False, False, False,
                    False, False, False, False, False, False, False, False,
                    False, False, False, False, False, False, False, False,
@@ -138,13 +129,14 @@ CV Results:
                    False, False, False, False, False, False, False, False,
                    False, False],
        fill_value='?',
-            dtype=object), 'param_C': masked_array(data=[100.0, 1000.0, 1e-05, 0.001, 1000.0, 0.01, 1e-05,
-                   10000.0, 10.0, 1000.0, 0.0001, 0.1, 100000.0, 1.0,
-                   1000000.0, 1000.0, 1.0, 1000.0, 0.1, 0.001, 0.1, 0.01,
-                   1.0, 0.1, 1.0, 0.0001, 1000.0, 0.01, 1000.0, 1000000.0,
-                   1.0, 100.0, 100.0, 1e-06, 1000.0, 0.01, 0.0001, 0.1,
-                   10000.0, 0.01, 0.0001, 100000.0, 0.01, 1e-06, 10000.0,
-                   1000000.0, 1000000.0, 10.0, 1000.0, 1000.0],
+            dtype=object), 'param_C': masked_array(data=[1000000.0, 0.01, 100000.0, 0.1, 1000.0, 0.1, 1.0,
+                   0.001, 100000.0, 1000.0, 1e-05, 100000.0, 0.1,
+                   1000000.0, 100.0, 0.0001, 0.1, 0.0001, 1.0, 1000000.0,
+                   1000000.0, 1000.0, 0.0001, 1e-05, 1000000.0, 1e-06,
+                   1.0, 1.0, 0.01, 0.0001, 100000.0, 1000000.0, 1000.0,
+                   1.0, 0.0001, 100.0, 10000.0, 0.0001, 0.001, 1e-05,
+                   1000.0, 0.001, 0.1, 0.0001, 100000.0, 10.0, 0.001,
+                   1e-05, 10000.0, 1000000.0],
              mask=[False, False, False, False, False, False, False, False,
                    False, False, False, False, False, False, False, False,
                    False, False, False, False, False, False, False, False,
@@ -153,59 +145,59 @@ CV Results:
                    False, False, False, False, False, False, False, False,
                    False, False],
        fill_value='?',
-            dtype=object), 'params': [{'tol': 0.0001, 'gamma': 10000.0, 'class_weight': 'balanced', 'C': 100.0}, {'tol': 0.0001, 'gamma': 1000.0, 'class_weight': None, 'C': 1000.0}, {'tol': 0.01, 'gamma': 100000.0, 'class_weight': 'balanced', 'C': 1e-05}, {'tol': 0.1, 'gamma': 0.01, 'class_weight': 'balanced', 'C': 0.001}, {'tol': 0.0001, 'gamma': 100000.0, 'class_weight': 'balanced', 'C': 1000.0}, {'tol': 0.1, 'gamma': 0.1, 'class_weight': 'balanced', 'C': 0.01}, {'tol': 0.001, 'gamma': 1e-08, 'class_weight': None, 'C': 1e-05}, {'tol': 0.1, 'gamma': 1000.0, 'class_weight': None, 'C': 10000.0}, {'tol': 0.1, 'gamma': 1e-05, 'class_weight': 'balanced', 'C': 10.0}, {'tol': 0.1, 'gamma': 10.0, 'class_weight': 'balanced', 'C': 1000.0}, {'tol': 0.01, 'gamma': 0.0001, 'class_weight': 'balanced', 'C': 0.0001}, {'tol': 0.0001, 'gamma': 0.1, 'class_weight': None, 'C': 0.1}, {'tol': 0.01, 'gamma': 0.01, 'class_weight': 'balanced', 'C': 100000.0}, {'tol': 0.1, 'gamma': 1e-08, 'class_weight': None, 'C': 1.0}, {'tol': 0.0001, 'gamma': 100000000.0, 'class_weight': 'balanced', 'C': 1000000.0}, {'tol': 0.1, 'gamma': 10.0, 'class_weight': None, 'C': 1000.0}, {'tol': 0.0001, 'gamma': 0.0001, 'class_weight': None, 'C': 1.0}, {'tol': 0.01, 'gamma': 0.001, 'class_weight': None, 'C': 1000.0}, {'tol': 0.0001, 'gamma': 1e-08, 'class_weight': None, 'C': 0.1}, {'tol': 0.1, 'gamma': 0.001, 'class_weight': 'balanced', 'C': 0.001}, {'tol': 0.01, 'gamma': 1e-07, 'class_weight': 'balanced', 'C': 0.1}, {'tol': 0.1, 'gamma': 100000000.0, 'class_weight': 'balanced', 'C': 0.01}, {'tol': 0.001, 'gamma': 10000000.0, 'class_weight': None, 'C': 1.0}, {'tol': 0.1, 'gamma': 100000.0, 'class_weight': 'balanced', 'C': 0.1}, {'tol': 0.01, 'gamma': 100000.0, 'class_weight': 'balanced', 'C': 1.0}, {'tol': 0.0001, 'gamma': 1e-05, 'class_weight': 'balanced', 'C': 0.0001}, {'tol': 0.01, 'gamma': 100.0, 'class_weight': None, 'C': 1000.0}, {'tol': 0.001, 'gamma': 100000.0, 'class_weight': None, 'C': 0.01}, {'tol': 0.01, 'gamma': 1e-07, 'class_weight': None, 'C': 1000.0}, {'tol': 0.01, 'gamma': 0.0001, 'class_weight': None, 'C': 1000000.0}, {'tol': 0.0001, 'gamma': 100000.0, 'class_weight': None, 'C': 1.0}, {'tol': 0.1, 'gamma': 1e-05, 'class_weight': None, 'C': 100.0}, {'tol': 0.01, 'gamma': 100000000.0, 'class_weight': None, 'C': 100.0}, {'tol': 0.1, 'gamma': 1.0, 'class_weight': 'balanced', 'C': 1e-06}, {'tol': 0.001, 'gamma': 1.0, 'class_weight': 'balanced', 'C': 1000.0}, {'tol': 0.001, 'gamma': 10000.0, 'class_weight': 'balanced', 'C': 0.01}, {'tol': 0.1, 'gamma': 0.1, 'class_weight': None, 'C': 0.0001}, {'tol': 0.01, 'gamma': 1.0, 'class_weight': 'balanced', 'C': 0.1}, {'tol': 0.0001, 'gamma': 10.0, 'class_weight': None, 'C': 10000.0}, {'tol': 0.01, 'gamma': 100000.0, 'class_weight': None, 'C': 0.01}, {'tol': 0.001, 'gamma': 0.01, 'class_weight': 'balanced', 'C': 0.0001}, {'tol': 0.01, 'gamma': 100.0, 'class_weight': None, 'C': 100000.0}, {'tol': 0.1, 'gamma': 100000.0, 'class_weight': None, 'C': 0.01}, {'tol': 0.0001, 'gamma': 100000.0, 'class_weight': 'balanced', 'C': 1e-06}, {'tol': 0.01, 'gamma': 1e-05, 'class_weight': None, 'C': 10000.0}, {'tol': 0.0001, 'gamma': 0.0001, 'class_weight': 'balanced', 'C': 1000000.0}, {'tol': 0.1, 'gamma': 100.0, 'class_weight': None, 'C': 1000000.0}, {'tol': 0.01, 'gamma': 0.0001, 'class_weight': None, 'C': 10.0}, {'tol': 0.0001, 'gamma': 1e-05, 'class_weight': 'balanced', 'C': 1000.0}, {'tol': 0.001, 'gamma': 1e-07, 'class_weight': 'balanced', 'C': 1000.0}], 'split0_test_score': array([0.10016694, 0.10016694, 0.0984975 , 0.14524207, 0.10016694,
-       0.0984975 , 0.29215359, 0.10016694, 0.94156928, 0.10016694,
-       0.19866444, 0.10016694, 0.66277129, 0.29215359, 0.10016694,
-       0.10016694, 0.94991653, 0.97161937, 0.29215359, 0.19866444,
-       0.19699499, 0.0984975 , 0.10016694, 0.0984975 , 0.10016694,
-       0.19699499, 0.10016694, 0.10016694, 0.94156928, 0.95158598,
-       0.10016694, 0.93656093, 0.10016694, 0.19866444, 0.20200334,
-       0.0984975 , 0.10016694, 0.19866444, 0.10016694, 0.10016694,
-       0.14524207, 0.10016694, 0.10016694, 0.0984975 , 0.94156928,
-       0.95158598, 0.10016694, 0.94490818, 0.93989983, 0.94156928]), 'split1_test_score': array([0.10183639, 0.10183639, 0.10016694, 0.0984975 , 0.10183639,
-       0.0984975 , 0.10183639, 0.10183639, 0.95492487, 0.10183639,
-       0.19866444, 0.10183639, 0.68948247, 0.10183639, 0.10183639,
-       0.10183639, 0.96327212, 0.98163606, 0.10183639, 0.0984975 ,
-       0.0984975 , 0.0984975 , 0.10183639, 0.0984975 , 0.10183639,
-       0.19866444, 0.10183639, 0.10183639, 0.95325543, 0.96327212,
-       0.10183639, 0.96661102, 0.10183639, 0.0984975 , 0.10183639,
-       0.0984975 , 0.10183639, 0.0984975 , 0.10183639, 0.10183639,
-       0.12687813, 0.10183639, 0.10183639, 0.0984975 , 0.95659432,
-       0.96327212, 0.10183639, 0.97161937, 0.95826377, 0.95158598]), 'split2_test_score': array([0.10183639, 0.10183639, 0.10016694, 0.0984975 , 0.10183639,
-       0.0984975 , 0.10183639, 0.10183639, 0.92654424, 0.10183639,
-       0.19866444, 0.10183639, 0.74457429, 0.10183639, 0.10183639,
-       0.10183639, 0.93155259, 0.97495826, 0.10183639, 0.0984975 ,
-       0.0984975 , 0.0984975 , 0.10183639, 0.0984975 , 0.10183639,
-       0.19866444, 0.10183639, 0.10183639, 0.92654424, 0.95158598,
-       0.10183639, 0.94156928, 0.10183639, 0.0984975 , 0.10183639,
-       0.0984975 , 0.10183639, 0.0984975 , 0.10183639, 0.10183639,
-       0.13188648, 0.10183639, 0.10183639, 0.0984975 , 0.93656093,
-       0.95158598, 0.10183639, 0.95325543, 0.93989983, 0.92654424]), 'mean_test_score': array([0.10127991, 0.10127991, 0.09961046, 0.11407902, 0.10127991,
-       0.0984975 , 0.16527546, 0.10127991, 0.9410128 , 0.10127991,
-       0.19866444, 0.10127991, 0.69894268, 0.16527546, 0.10127991,
-       0.10127991, 0.94824708, 0.97607123, 0.16527546, 0.13188648,
-       0.13132999, 0.0984975 , 0.10127991, 0.0984975 , 0.10127991,
-       0.19810796, 0.10127991, 0.10127991, 0.94045632, 0.95548136,
-       0.10127991, 0.94824708, 0.10127991, 0.13188648, 0.13522538,
-       0.0984975 , 0.10127991, 0.13188648, 0.10127991, 0.10127991,
-       0.13466889, 0.10127991, 0.10127991, 0.0984975 , 0.94490818,
-       0.95548136, 0.10127991, 0.95659432, 0.94602115, 0.93989983]), 'std_test_score': array([0.00078699, 0.00078699, 0.00078699, 0.0220356 , 0.00078699,
-       0.        , 0.08971639, 0.00078699, 0.01159303, 0.00078699,
-       0.        , 0.00078699, 0.03405931, 0.08971639, 0.00078699,
-       0.00078699, 0.01300314, 0.00416434, 0.08971639, 0.04721915,
-       0.04643216, 0.        , 0.00078699, 0.        , 0.00078699,
-       0.00078699, 0.00078699, 0.00078699, 0.01093316, 0.0055089 ,
-       0.00078699, 0.01314526, 0.00078699, 0.04721915, 0.04721915,
-       0.        , 0.00078699, 0.04721915, 0.00078699, 0.00078699,
-       0.00775091, 0.00078699, 0.00078699, 0.        , 0.00851255,
-       0.0055089 , 0.00078699, 0.01115745, 0.00865684, 0.01029118]), 'rank_test_score': array([25, 25, 45, 24, 25, 46, 15, 25,  9, 25, 13, 25, 12, 15, 25, 25,  5,
-        1, 15, 20, 23, 46, 25, 46, 25, 14, 25, 25, 10,  3, 25,  5, 25, 20,
-       18, 46, 25, 20, 25, 25, 19, 25, 25, 46,  8,  3, 25,  2,  7, 11],
+            dtype=object), 'params': [{'tol': 0.0001, 'gamma': 1e-06, 'class_weight': 'balanced', 'C': 1000000.0}, {'tol': 0.1, 'gamma': 1e-05, 'class_weight': None, 'C': 0.01}, {'tol': 0.001, 'gamma': 0.0001, 'class_weight': 'balanced', 'C': 100000.0}, {'tol': 0.001, 'gamma': 100000.0, 'class_weight': None, 'C': 0.1}, {'tol': 0.001, 'gamma': 0.1, 'class_weight': None, 'C': 1000.0}, {'tol': 0.1, 'gamma': 1e-06, 'class_weight': None, 'C': 0.1}, {'tol': 0.01, 'gamma': 1e-05, 'class_weight': None, 'C': 1.0}, {'tol': 0.001, 'gamma': 10000000.0, 'class_weight': None, 'C': 0.001}, {'tol': 0.0001, 'gamma': 1e-06, 'class_weight': None, 'C': 100000.0}, {'tol': 0.0001, 'gamma': 0.1, 'class_weight': 'balanced', 'C': 1000.0}, {'tol': 0.1, 'gamma': 100.0, 'class_weight': None, 'C': 1e-05}, {'tol': 0.0001, 'gamma': 1e-06, 'class_weight': 'balanced', 'C': 100000.0}, {'tol': 0.001, 'gamma': 100.0, 'class_weight': 'balanced', 'C': 0.1}, {'tol': 0.0001, 'gamma': 10000.0, 'class_weight': None, 'C': 1000000.0}, {'tol': 0.1, 'gamma': 100.0, 'class_weight': None, 'C': 100.0}, {'tol': 0.0001, 'gamma': 1e-06, 'class_weight': 'balanced', 'C': 0.0001}, {'tol': 0.01, 'gamma': 10000000.0, 'class_weight': None, 'C': 0.1}, {'tol': 0.1, 'gamma': 0.0001, 'class_weight': None, 'C': 0.0001}, {'tol': 0.01, 'gamma': 0.01, 'class_weight': None, 'C': 1.0}, {'tol': 0.001, 'gamma': 1000000.0, 'class_weight': 'balanced', 'C': 1000000.0}, {'tol': 0.01, 'gamma': 0.1, 'class_weight': 'balanced', 'C': 1000000.0}, {'tol': 0.01, 'gamma': 1000.0, 'class_weight': 'balanced', 'C': 1000.0}, {'tol': 0.001, 'gamma': 1e-06, 'class_weight': 'balanced', 'C': 0.0001}, {'tol': 0.001, 'gamma': 1e-08, 'class_weight': None, 'C': 1e-05}, {'tol': 0.01, 'gamma': 10000000.0, 'class_weight': 'balanced', 'C': 1000000.0}, {'tol': 0.0001, 'gamma': 1e-08, 'class_weight': None, 'C': 1e-06}, {'tol': 0.001, 'gamma': 0.001, 'class_weight': 'balanced', 'C': 1.0}, {'tol': 0.1, 'gamma': 1000.0, 'class_weight': None, 'C': 1.0}, {'tol': 0.001, 'gamma': 1e-05, 'class_weight': None, 'C': 0.01}, {'tol': 0.001, 'gamma': 0.001, 'class_weight': 'balanced', 'C': 0.0001}, {'tol': 0.01, 'gamma': 1e-06, 'class_weight': 'balanced', 'C': 100000.0}, {'tol': 0.01, 'gamma': 10.0, 'class_weight': None, 'C': 1000000.0}, {'tol': 0.001, 'gamma': 1000.0, 'class_weight': 'balanced', 'C': 1000.0}, {'tol': 0.01, 'gamma': 10000.0, 'class_weight': None, 'C': 1.0}, {'tol': 0.1, 'gamma': 100000.0, 'class_weight': 'balanced', 'C': 0.0001}, {'tol': 0.01, 'gamma': 10000.0, 'class_weight': None, 'C': 100.0}, {'tol': 0.01, 'gamma': 0.01, 'class_weight': 'balanced', 'C': 10000.0}, {'tol': 0.0001, 'gamma': 100.0, 'class_weight': None, 'C': 0.0001}, {'tol': 0.0001, 'gamma': 10000000.0, 'class_weight': None, 'C': 0.001}, {'tol': 0.1, 'gamma': 1000000.0, 'class_weight': None, 'C': 1e-05}, {'tol': 0.1, 'gamma': 1.0, 'class_weight': 'balanced', 'C': 1000.0}, {'tol': 0.0001, 'gamma': 1000.0, 'class_weight': None, 'C': 0.001}, {'tol': 0.1, 'gamma': 100000000.0, 'class_weight': None, 'C': 0.1}, {'tol': 0.001, 'gamma': 100000.0, 'class_weight': None, 'C': 0.0001}, {'tol': 0.001, 'gamma': 1e-07, 'class_weight': 'balanced', 'C': 100000.0}, {'tol': 0.0001, 'gamma': 1e-08, 'class_weight': None, 'C': 10.0}, {'tol': 0.1, 'gamma': 1e-08, 'class_weight': 'balanced', 'C': 0.001}, {'tol': 0.1, 'gamma': 1e-08, 'class_weight': 'balanced', 'C': 1e-05}, {'tol': 0.1, 'gamma': 0.001, 'class_weight': 'balanced', 'C': 10000.0}, {'tol': 0.1, 'gamma': 0.001, 'class_weight': None, 'C': 1000000.0}], 'split0_test_score': array([0.93656093, 0.29215359, 0.95158598, 0.10016694, 0.10183639,
+       0.29215359, 0.89315526, 0.10016694, 0.93656093, 0.10183639,
+       0.10016694, 0.93656093, 0.0984975 , 0.10016694, 0.10016694,
+       0.19699499, 0.10016694, 0.29549249, 0.65275459, 0.10016694,
+       0.10183639, 0.10016694, 0.19699499, 0.29215359, 0.10016694,
+       0.29215359, 0.96828047, 0.10016694, 0.29215359, 0.19866444,
+       0.93656093, 0.10016694, 0.10016694, 0.10016694, 0.0984975 ,
+       0.10016694, 0.66277129, 0.10016694, 0.10016694, 0.10016694,
+       0.20200334, 0.10016694, 0.10016694, 0.10016694, 0.93656093,
+       0.29215359, 0.19699499, 0.19699499, 0.96994992, 0.96994992]), 'split1_test_score': array([0.95826377, 0.10183639, 0.96327212, 0.10183639, 0.10183639,
+       0.10183639, 0.88313856, 0.10183639, 0.95826377, 0.10183639,
+       0.10183639, 0.95826377, 0.0984975 , 0.10183639, 0.10183639,
+       0.19866444, 0.10183639, 0.10183639, 0.68447412, 0.10183639,
+       0.10183639, 0.10183639, 0.19866444, 0.10183639, 0.10183639,
+       0.10183639, 0.98163606, 0.10183639, 0.10183639, 0.19866444,
+       0.95659432, 0.10183639, 0.10183639, 0.10183639, 0.10016694,
+       0.10183639, 0.68948247, 0.10183639, 0.10183639, 0.10183639,
+       0.10183639, 0.10183639, 0.10183639, 0.10183639, 0.95659432,
+       0.10183639, 0.0984975 , 0.19866444, 0.98163606, 0.98163606]), 'split2_test_score': array([0.93823038, 0.10183639, 0.95158598, 0.10183639, 0.10183639,
+       0.10183639, 0.86477462, 0.10183639, 0.93823038, 0.10183639,
+       0.10183639, 0.93823038, 0.0984975 , 0.10183639, 0.10183639,
+       0.19866444, 0.10183639, 0.10183639, 0.73789649, 0.10183639,
+       0.10183639, 0.10183639, 0.19866444, 0.10183639, 0.10183639,
+       0.10183639, 0.97328881, 0.10183639, 0.10183639, 0.19866444,
+       0.93823038, 0.10183639, 0.10183639, 0.10183639, 0.10016694,
+       0.10183639, 0.74457429, 0.10183639, 0.10183639, 0.10183639,
+       0.10183639, 0.10183639, 0.10183639, 0.10183639, 0.93823038,
+       0.10183639, 0.0984975 , 0.19866444, 0.97662771, 0.97662771]), 'mean_test_score': array([0.9443517 , 0.16527546, 0.95548136, 0.10127991, 0.10183639,
+       0.16527546, 0.88035615, 0.10127991, 0.9443517 , 0.10183639,
+       0.10127991, 0.9443517 , 0.0984975 , 0.10127991, 0.10127991,
+       0.19810796, 0.10127991, 0.16638843, 0.6917084 , 0.10127991,
+       0.10183639, 0.10127991, 0.19810796, 0.16527546, 0.10127991,
+       0.16527546, 0.97440178, 0.10127991, 0.16527546, 0.19866444,
+       0.94379521, 0.10127991, 0.10127991, 0.10127991, 0.09961046,
+       0.10127991, 0.69894268, 0.10127991, 0.10127991, 0.10127991,
+       0.13522538, 0.10127991, 0.10127991, 0.10127991, 0.94379521,
+       0.16527546, 0.13132999, 0.19810796, 0.97607123, 0.97607123]), 'std_test_score': array([0.0098609 , 0.08971639, 0.0055089 , 0.00078699, 0.        ,
+       0.08971639, 0.0117522 , 0.00078699, 0.0098609 , 0.        ,
+       0.00078699, 0.0098609 , 0.        , 0.00078699, 0.00078699,
+       0.00078699, 0.00078699, 0.09129036, 0.03513343, 0.00078699,
+       0.        , 0.00078699, 0.00078699, 0.08971639, 0.00078699,
+       0.08971639, 0.0055089 , 0.00078699, 0.08971639, 0.        ,
+       0.00907596, 0.00078699, 0.00078699, 0.00078699, 0.00078699,
+       0.00078699, 0.03405931, 0.00078699, 0.00078699, 0.00078699,
+       0.04721915, 0.00078699, 0.00078699, 0.00078699, 0.00907596,
+       0.08971639, 0.04643216, 0.00078699, 0.00478705, 0.00478705]), 'rank_test_score': array([ 5, 18,  4, 29, 26, 18, 10, 29,  5, 26, 29,  5, 50, 29, 29, 14, 29,
+       17, 12, 29, 26, 29, 14, 18, 29, 18,  3, 29, 18, 13,  8, 29, 29, 29,
+       49, 29, 11, 29, 29, 29, 24, 29, 29, 29,  8, 18, 25, 14,  1,  1],
       dtype=int32)}
 
 Best Params
-{'tol': 0.01, 'gamma': 0.001, 'class_weight': None, 'C': 1000.0}
-Sleeping 2 minutes to keep job alive if you want to interact!
+{'tol': 0.1, 'gamma': 0.001, 'class_weight': 'balanced', 'C': 10000.0}
+Sleeping for two minutes to keep job alive if you want to interact!
 ```
 
 </details>
@@ -218,49 +210,145 @@ $ sudo -u fluxuser -E $(env) -E HOME=/home/fluxuser flux proxy local:///run/flux
 ```
 
 For those interested, when I did this above and looked at the flux jobs submit `flux jobs -a` (to distribute the training)
-I saw that indeed, it was distributed across the workers. Notice that we are hitting all the nodes.
+I saw that indeed, it was distributed across the four workers. Notice that we are hitting all the nodes.
 
 ```bash
 $ flux jobs -a
 ```
 ```console
+fluxuser@flux-sample-0:/tmp/workflow$ flux jobs -a
        JOBID USER     NAME       ST NTASKS NNODES     TIME INFO
-    ƒAHuVwM1 fluxuser flux-job-+  S      1      -        - 
-    ƒ9QwJdRR fluxuser flux-job-+  R      1      1   8.019s flux-sample-3
-    ƒ7ebCD4j fluxuser flux-job-+  R      1      1   12.02s flux-sample-0
-    ƒ5T6FyQj fluxuser flux-job-+  R      1      1   17.01s flux-sample-1
-    ƒ3gfhbD1 fluxuser flux-job-+  R      1      1   21.02s flux-sample-2
-    ƒ26RCHAX fluxuser flux-job-+ CD      1      1   5.370s flux-sample-3
+    ƒ7chV8DD fluxuser dask-work+  R      1      1   1.014s flux-sample-0
+    ƒ7XHBkU7 fluxuser dask-work+  R      1      1   1.227s flux-sample-1
+    ƒ7T7XmXu fluxuser dask-work+  R      1      1   1.390s flux-sample-2
+    ƒ7NmVsdH fluxuser dask-work+  R      1      1   1.548s flux-sample-3
 ```
+
+It will keep scheduling jobs across workers generally until the task is done. At the end,
+I notice that some of the workers just continue to run, and I suspect they will keep going
+until the main broker quits (when the job ends) and then the user (you!) can delete
+the MiniCluster. If you are interested in what the Dask worker log looks like, take a look
+at the flux output files in the present directory (where we submit from):
+
+```bash
+$ ls *.out
+```
+```console
+flux-ƒ5G6mJET.out  flux-ƒ5WYQJTH.out  flux-ƒ76S9nYw.out  flux-ƒ8Qi4qTu.out
+flux-ƒ5KgKZgj.out  flux-ƒ6u2wJs9.out  flux-ƒ7BebG3H.out  flux-ƒ99HzCxP.out
+flux-ƒ5Q5KSA3.out  flux-ƒ6yZM7kB.out  flux-ƒ8KiyFWf.out
+```
+
+<detailks>
+
+<summary>Example worker output</summary>
+
+```console
+2023-04-23 20:44:31,767 - distributed.nanny - INFO -         Start Nanny at: 'tcp://10.244.0.108:42779'
+2023-04-23 20:44:32,542 - distributed.worker - INFO -       Start worker at:   tcp://10.244.0.108:45325
+2023-04-23 20:44:32,542 - distributed.worker - INFO -          Listening to:   tcp://10.244.0.108:45325
+2023-04-23 20:44:32,542 - distributed.worker - INFO -           Worker name:              FluxCluster-7
+2023-04-23 20:44:32,542 - distributed.worker - INFO -          dashboard at:         10.244.0.108:33503
+2023-04-23 20:44:32,542 - distributed.worker - INFO - Waiting to connect to:   tcp://10.244.0.109:36893
+2023-04-23 20:44:32,543 - distributed.worker - INFO - -------------------------------------------------
+2023-04-23 20:44:32,543 - distributed.worker - INFO -               Threads:                          2
+2023-04-23 20:44:32,543 - distributed.worker - INFO -                Memory:                   1.86 GiB
+2023-04-23 20:44:32,543 - distributed.worker - INFO -       Local Directory: /tmp/workflow/tmp/dask-worker-space/worker-8azkycka
+2023-04-23 20:44:32,543 - distributed.worker - INFO - -------------------------------------------------
+2023-04-23 20:44:32,796 - distributed.worker - INFO -         Registered to:   tcp://10.244.0.109:36893
+2023-04-23 20:44:32,796 - distributed.worker - INFO - -------------------------------------------------
+2023-04-23 20:44:32,797 - distributed.core - INFO - Starting established connection to tcp://10.244.0.109:36893
+(base) vanessa@vanessa-ThinkPad-T490s:~/Desktop/Code/flux/operator/examples/machine-learning/dask/scikit-learn$ cat flux-ƒ5
+flux-ƒ5G6mJET.out  flux-ƒ5KgKZgj.out  flux-ƒ5Q5KSA3.out  flux-ƒ5WYQJTH.out
+(base) vanessa@vanessa-ThinkPad-T490s:~/Desktop/Code/flux/operator/examples/machine-learning/dask/scikit-learn$ cat flux-ƒ5G6mJET.out 
+2023-04-23 20:44:04,573 - distributed.nanny - INFO -         Start Nanny at: 'tcp://10.244.0.106:43619'
+2023-04-23 20:44:05,507 - distributed.worker - INFO -       Start worker at:   tcp://10.244.0.106:43461
+2023-04-23 20:44:05,507 - distributed.worker - INFO -          Listening to:   tcp://10.244.0.106:43461
+2023-04-23 20:44:05,508 - distributed.worker - INFO -           Worker name:              FluxCluster-1
+2023-04-23 20:44:05,508 - distributed.worker - INFO -          dashboard at:         10.244.0.106:34977
+2023-04-23 20:44:05,508 - distributed.worker - INFO - Waiting to connect to:   tcp://10.244.0.109:36893
+2023-04-23 20:44:05,508 - distributed.worker - INFO - -------------------------------------------------
+2023-04-23 20:44:05,509 - distributed.worker - INFO -               Threads:                          2
+2023-04-23 20:44:05,509 - distributed.worker - INFO -                Memory:                   1.86 GiB
+2023-04-23 20:44:05,509 - distributed.worker - INFO -       Local Directory: /tmp/workflow/tmp/dask-worker-space/worker-de9bramy
+2023-04-23 20:44:05,509 - distributed.worker - INFO - -------------------------------------------------
+2023-04-23 20:44:05,796 - distributed.worker - INFO -         Registered to:   tcp://10.244.0.109:36893
+2023-04-23 20:44:05,796 - distributed.worker - INFO - -------------------------------------------------
+2023-04-23 20:44:05,796 - distributed.core - INFO - Starting established connection to tcp://10.244.0.109:36893
+2023-04-23 20:44:23,353 - distributed.worker - INFO - Stopping worker at tcp://10.244.0.106:43461. Reason: scheduler-remove-worker
+2023-04-23 20:44:23,361 - distributed.nanny - INFO - Closing Nanny gracefully at 'tcp://10.244.0.106:43619'. Reason: scheduler-remove-worker
+2023-04-23 20:44:23,436 - distributed.core - INFO - Connection to tcp://10.244.0.109:36893 has been closed.
+2023-04-23 20:44:23,442 - distributed.nanny - INFO - Worker closed
+[CV 2/3; 4/50] START C=0.1, class_weight=None, gamma=100000.0, tol=0.001........
+[CV 3/3; 5/50] START C=1000.0, class_weight=None, gamma=0.1, tol=0.001..........
+[CV 2/3; 4/50] END C=0.1, class_weight=None, gamma=100000.0, tol=0.001;, score=0.102 total time=   0.6s
+[CV 3/3; 2/50] START C=0.01, class_weight=None, gamma=1e-05, tol=0.1............
+[CV 3/3; 5/50] END C=1000.0, class_weight=None, gamma=0.1, tol=0.001;, score=0.102 total time=   1.0s
+[CV 3/3; 1/50] START C=1000000.0, class_weight=balanced, gamma=1e-06, tol=0.0001
+[CV 3/3; 2/50] END C=0.01, class_weight=None, gamma=1e-05, tol=0.1;, score=0.102 total time=   0.6s
+[CV 3/3; 7/50] START C=1.0, class_weight=None, gamma=1e-05, tol=0.01............
+[CV 3/3; 1/50] END C=1000000.0, class_weight=balanced, gamma=1e-06, tol=0.0001;, score=0.938 total time=   0.4s
+[CV 3/3; 8/50] START C=0.001, class_weight=None, gamma=10000000.0, tol=0.001....
+[CV 3/3; 7/50] END C=1.0, class_weight=None, gamma=1e-05, tol=0.01;, score=0.865 total time=   0.6s
+[CV 2/3; 9/50] START C=100000.0, class_weight=None, gamma=1e-06, tol=0.0001.....
+[CV 3/3; 8/50] END C=0.001, class_weight=None, gamma=10000000.0, tol=0.001;, score=0.102 total time=   0.6s
+[CV 3/3; 9/50] START C=100000.0, class_weight=None, gamma=1e-06, tol=0.0001.....
+[CV 3/3; 9/50] END C=100000.0, class_weight=None, gamma=1e-06, tol=0.0001;, score=0.938 total time=   0.2s
+[CV 2/3; 11/50] START C=1e-05, class_weight=None, gamma=100.0, tol=0.1..........
+[CV 2/3; 9/50] END C=100000.0, class_weight=None, gamma=1e-06, tol=0.0001;, score=0.958 total time=   0.5s
+[CV 2/3; 12/50] START C=100000.0, class_weight=balanced, gamma=1e-06, tol=0.0001
+[CV 2/3; 11/50] END C=1e-05, class_weight=None, gamma=100.0, tol=0.1;, score=0.102 total time=   0.6s
+[CV 3/3; 14/50] START C=1000000.0, class_weight=None, gamma=10000.0, tol=0.0001.
+[CV 2/3; 12/50] END C=100000.0, class_weight=balanced, gamma=1e-06, tol=0.0001;, score=0.958 total time=   0.3s
+[CV 2/3; 15/50] START C=100.0, class_weight=None, gamma=100.0, tol=0.1..........
+[CV 3/3; 14/50] END C=1000000.0, class_weight=None, gamma=10000.0, tol=0.0001;, score=0.102 total time=   0.6s
+[CV 2/3; 13/50] START C=0.1, class_weight=balanced, gamma=100.0, tol=0.001......
+[CV 2/3; 13/50] END C=0.1, class_weight=balanced, gamma=100.0, tol=0.001;, score=0.098 total time=   0.4s
+[CV 2/3; 17/50] START C=0.1, class_weight=None, gamma=10000000.0, tol=0.01......
+[CV 2/3; 15/50] END C=100.0, class_weight=None, gamma=100.0, tol=0.1;, score=0.102 total time=   1.2s
+[CV 3/3; 18/50] START C=0.0001, class_weight=None, gamma=0.0001, tol=0.1........
+[CV 2/3; 17/50] END C=0.1, class_weight=None, gamma=10000000.0, tol=0.01;, score=0.102 total time=   0.7s
+[CV 2/3; 20/50] START C=1000000.0, class_weight=balanced, gamma=1000000.0, tol=0.001
+[CV 2/3; 20/50] END C=1000000.0, class_weight=balanced, gamma=1000000.0, tol=0.001;, score=0.102 total time=   0.4s
+[CV 2/3; 22/50] START C=1000.0, class_weight=balanced, gamma=1000.0, tol=0.01...
+[CV 3/3; 18/50] END C=0.0001, class_weight=None, gamma=0.0001, tol=0.1;, score=0.102 total time=   0.8s
+[CV 3/3; 20/50] START C=1000000.0, class_weight=balanced, gamma=1000000.0, tol=0.001
+[CV 2/3; 22/50] END C=1000.0, class_weight=balanced, gamma=1000.0, tol=0.01;, score=0.102 total time=   1.4s
+[CV 3/3; 20/50] END C=1000000.0, class_weight=balanced, gamma=1000000.0, tol=0.001;, score=0.102 total time=   1.4s
+[CV 2/3; 31/50] START C=100000.0, class_weight=balanced, gamma=1e-06, tol=0.01..
+[CV 3/3; 31/50] START C=100000.0, class_weight=balanced, gamma=1e-06, tol=0.01..
+[CV 3/3; 31/50] END C=100000.0, class_weight=balanced, gamma=1e-06, tol=0.01;, score=0.938 total time=   0.1s
+[CV 2/3; 32/50] START C=1000000.0, class_weight=None, gamma=10.0, tol=0.01......
+[CV 2/3; 31/50] END C=100000.0, class_weight=balanced, gamma=1e-06, tol=0.01;, score=0.957 total time=   0.2s
+[CV 1/3; 33/50] START C=1000.0, class_weight=balanced, gamma=1000.0, tol=0.001..
+[CV 1/3; 33/50] END C=1000.0, class_weight=balanced, gamma=1000.0, tol=0.001;, score=0.100 total time=   1.2s
+[CV 2/3; 37/50] START C=10000.0, class_weight=balanced, gamma=0.01, tol=0.01....
+[CV 2/3; 32/50] END C=1000000.0, class_weight=None, gamma=10.0, tol=0.01;, score=0.102 total time=   2.2s
+[CV 3/3; 36/50] START C=100.0, class_weight=None, gamma=10000.0, tol=0.01.......
+[CV 2/3; 37/50] END C=10000.0, class_weight=balanced, gamma=0.01, tol=0.01;, score=0.689 total time=   1.4s
+[CV 2/3; 40/50] START C=1e-05, class_weight=None, gamma=1000000.0, tol=0.1......
+[CV 3/3; 36/50] END C=100.0, class_weight=None, gamma=10000.0, tol=0.01;, score=0.102 total time=   1.1s
+[CV 1/3; 43/50] START C=0.1, class_weight=None, gamma=100000000.0, tol=0.1......
+[CV 1/3; 43/50] END C=0.1, class_weight=None, gamma=100000000.0, tol=0.1;, score=0.100 total time=   1.4s
+[CV 1/3; 48/50] START C=1e-05, class_weight=balanced, gamma=1e-08, tol=0.1......
+[CV 2/3; 40/50] END C=1e-05, class_weight=None, gamma=1000000.0, tol=0.1;, score=0.102 total time=   2.9s
+[CV 1/3; 50/50] START C=1000000.0, class_weight=None, gamma=0.001, tol=0.1......
+[CV 1/3; 50/50] END C=1000000.0, class_weight=None, gamma=0.001, tol=0.1;, score=0.970 total time=   0.3s
+[CV 1/3; 48/50] END C=1e-05, class_weight=balanced, gamma=1e-08, tol=0.1;, score=0.197 total time=   1.4s
+2023-04-23 20:44:26,257 - distributed.nanny - INFO - Closing Nanny at 'tcp://10.244.0.106:43619'. Reason: nanny-close-gracefully
+2023-04-23 20:44:26,259 - distributed.dask_worker - INFO - End worker
+```
+
+</details>
 
 ### Notes
 
-#### Waiting for workers
-
-What I think I saw happening is that a first job was submit that acted as a "nanny" and this
-nanny we can ask to wait for workers (see the script). Now, these workers aren't actually the nodes, but 
-rather processes on one node (because it's launched by one job). So for that parameter I provided the number of cores.
-If you provide the number of workers (and it's more than the number of cores) you will time out!
-
 #### Submitting to Flux
 
-I did this `flux jobs -a` ultiamtely as a sanity check that dask was actually submitting jobs to Flux, and it was.
-It does seem like dask doesn't really predict how many workers it will need - it just launches them and the entire
+I did this `flux jobs -a` ultiamtely as a sanity check that dask was actually submitting batch jobs to Flux, and it was.
+It does seem like dask doesn't really predict how many of these batch jobs it will need - it just launches them and the entire
 training finishes at some point, and the others can just hang out waiting for more work. I'm sure
 this can be tweaked. But seriously, that's so cool! 
-
-#### Cleaning Up
-
-I'm not sure about the logic of cleaning up, because when I used a branch that cleans up when a worker finishes,
-I had failed jobs that said they couldn't find the script they were supposed to run. For the time being (until
-we understand how to properly cleanup) I have commented out this line. It could be that
-the cancel command is not properly going through, or some function call on my part that we are done
-needs to happen.
-
-#### Pre-built image
-
-Finally, if you build your image with dask already installed you'll save a bit of time! I also
-would play around with the waiting time for the cluster - it likely can be shortened.
 
 ### Cleanup
 
@@ -270,9 +358,9 @@ When you are done, clean up:
 $ kubectl delete -f minicluster.yaml
 ```
 
-Make sure to clean up your temporary tmpdir, because something cached from a previous run could potentially interfere with
-a new one! I found that when I didn't clean up, the subsequent run timed out looking for the workers (likely because of some cache?)
+Make sure to clean up your shared tmpdir!
 
 ```bash
+$ rm *.out
 $ sudo rm -rf ./tmp/*
 ```

--- a/examples/machine-learning/dask/scikit-learn/README.md
+++ b/examples/machine-learning/dask/scikit-learn/README.md
@@ -1,0 +1,278 @@
+# Dask with scikit-learn and Flux!
+
+This will test running [Dask and scikit-learn](https://ml.dask.org/joblib.html) with Flux.
+Our goal is to do this simply, and eventually extend this to a more complex hierarchy of jobs.
+
+## Usage
+
+First, let's create a kind cluster.
+
+```bash
+$ kind create cluster --config ../../../kind-config.yaml
+```
+
+And then install the operator, create the namespace, and apply the MiniCluster YAML here.
+
+```bash
+$ kubectl apply -f ../../../dist/flux-operator.yaml
+$ kubectl create namespace flux-operator
+$ kubectl apply -f ./minicluster.yaml
+```
+
+This will install dependencies (dask and scikit-learn) directly into the base image, and then mount
+the current directory (in the pods as `/tmp/workflow`). We run the [launch.py](launch.py)
+script from the broker, and you can inspect this script to see how we create and connect
+to Flux. There is currently a generous timeout (60 seconds) to ensure
+the cluster is ready. You can watch logs doing the following: 
+
+```bash
+$ kubectl logs -n flux-operator flux-sample-0-7tx7s -f
+```
+
+Since I wrote this as a demo, I basically did model training, and then printed the final CV results
+and parameters. You'll see this in the log (expand the section below):
+
+<details>
+
+<summary>Output of Scikit-Learn Example</summary>
+
+```console
+...
+broker.info[0]: rc1.0: running /etc/flux/rc1.d/01-sched-fluxion
+sched-fluxion-resource.info[0]: version 214aa27
+sched-fluxion-resource.warning[0]: create_reader: allowlist unsupported
+sched-fluxion-resource.info[0]: populate_resource_db: loaded resources from core's resource.acquire
+sched-fluxion-qmanager.info[0]: version 214aa27
+broker.info[0]: rc1.0: running /etc/flux/rc1.d/02-cron
+broker.info[0]: rc1.0: /etc/flux/rc1 Exited (rc=0) 3.8s
+broker.info[0]: rc1-success: init->quorum 3.8019s
+broker.info[0]: online: flux-sample-0 (ranks 0)
+broker.info[0]: online: flux-sample-[0-3] (ranks 0-3)
+broker.info[0]: quorum-full: quorum->run 3.99891s
+     nodes: 4
+     cores: 2
+   timeout: 60
+Fitting model...
+Fitting 3 folds for each of 50 candidates, totalling 150 fits
+CV Results:
+{'mean_fit_time': array([4.08554602, 5.423575  , 3.39528402, 2.85911171, 4.831592  ,
+       3.88271205, 3.02563477, 2.47843599, 0.68565289, 2.93963766,
+       3.39221478, 3.79691935, 3.96530684, 3.82564553, 4.97321709,
+       3.84288883, 1.15530101, 1.35951893, 3.7286648 , 4.03004575,
+       3.66520365, 3.37004209, 3.13437613, 2.99476473, 2.26174323,
+       3.39319603, 2.89181201, 2.62760369, 0.65904252, 0.39908274,
+       3.00021768, 0.34174371, 3.26659242, 3.26887321, 3.08342997,
+       2.61445681, 3.21243397, 3.22617459, 3.29642828, 2.41557391,
+       3.36702911, 3.24384109, 2.87103478, 2.92750065, 0.34344927,
+       0.5176696 , 2.61106515, 0.41769854, 0.67651065, 0.86017307]), 'std_fit_time': array([1.29295808, 0.44993044, 1.13105463, 0.24890695, 1.53956746,
+       0.93328344, 0.66994432, 0.16029377, 0.17592682, 0.12820939,
+       0.37487107, 0.68207106, 0.36123274, 0.27662093, 0.44998325,
+       0.11232528, 0.15331819, 0.29612327, 0.23260674, 0.20277183,
+       0.10520431, 0.34012566, 0.15273326, 0.25142427, 0.26527932,
+       0.10249256, 0.11939426, 0.40004664, 0.02033139, 0.06673623,
+       0.05008267, 0.05227693, 0.29535088, 0.14343989, 0.26508654,
+       0.20566045, 0.40562526, 0.30273003, 0.62674814, 0.09708462,
+       0.41936624, 0.34741114, 0.15964411, 0.2086272 , 0.04933951,
+       0.01189969, 0.22959803, 0.08866899, 0.05076011, 0.12571382]), 'mean_score_time': array([2.26498397, 1.77561784, 1.6284159 , 2.33371989, 1.4934899 ,
+       1.65991545, 1.01165613, 1.26928711, 0.80194203, 1.01934727,
+       1.14952954, 1.31477968, 2.05600015, 1.86737108, 1.60693971,
+       1.95683328, 0.96571255, 1.25838002, 0.99948716, 1.46727578,
+       0.9671642 , 1.23076653, 1.0414288 , 1.23779511, 1.16715463,
+       1.123487  , 0.96316584, 1.07391651, 0.62996387, 0.42405613,
+       1.30649598, 0.31687458, 1.05327328, 1.01003925, 1.0420777 ,
+       0.98385247, 1.26904154, 1.24301561, 1.3658274 , 1.24738073,
+       1.36005807, 1.32252598, 1.04261764, 1.03164657, 0.29092725,
+       0.48727504, 0.32448387, 0.60944939, 0.42013979, 0.33401561]), 'std_score_time': array([0.20775316, 0.24286407, 0.11926821, 0.40169773, 0.55680183,
+       0.78485425, 0.17111927, 0.06430806, 0.1293463 , 0.23254882,
+       0.26622301, 0.2448651 , 0.21866524, 0.3043432 , 0.11532111,
+       0.35099115, 0.02410389, 0.02678309, 0.2368529 , 0.13744223,
+       0.1707387 , 0.17363425, 0.07558077, 0.02828425, 0.04064274,
+       0.07727504, 0.03594565, 0.03109774, 0.16673041, 0.12429896,
+       0.26720998, 0.06015071, 0.24929352, 0.15515904, 0.10645853,
+       0.12264939, 0.19762409, 0.29526357, 0.08137586, 0.23999344,
+       0.21649012, 0.16955293, 0.10475885, 0.22040064, 0.07748718,
+       0.02336777, 0.0849569 , 0.20914747, 0.09983006, 0.12743123]), 'param_tol': masked_array(data=[0.0001, 0.0001, 0.01, 0.1, 0.0001, 0.1, 0.001, 0.1,
+                   0.1, 0.1, 0.01, 0.0001, 0.01, 0.1, 0.0001, 0.1, 0.0001,
+                   0.01, 0.0001, 0.1, 0.01, 0.1, 0.001, 0.1, 0.01, 0.0001,
+                   0.01, 0.001, 0.01, 0.01, 0.0001, 0.1, 0.01, 0.1, 0.001,
+                   0.001, 0.1, 0.01, 0.0001, 0.01, 0.001, 0.01, 0.1,
+                   0.0001, 0.01, 0.0001, 0.1, 0.01, 0.0001, 0.001],
+             mask=[False, False, False, False, False, False, False, False,
+                   False, False, False, False, False, False, False, False,
+                   False, False, False, False, False, False, False, False,
+                   False, False, False, False, False, False, False, False,
+                   False, False, False, False, False, False, False, False,
+                   False, False, False, False, False, False, False, False,
+                   False, False],
+       fill_value='?',
+            dtype=object), 'param_gamma': masked_array(data=[10000.0, 1000.0, 100000.0, 0.01, 100000.0, 0.1, 1e-08,
+                   1000.0, 1e-05, 10.0, 0.0001, 0.1, 0.01, 1e-08,
+                   100000000.0, 10.0, 0.0001, 0.001, 1e-08, 0.001, 1e-07,
+                   100000000.0, 10000000.0, 100000.0, 100000.0, 1e-05,
+                   100.0, 100000.0, 1e-07, 0.0001, 100000.0, 1e-05,
+                   100000000.0, 1.0, 1.0, 10000.0, 0.1, 1.0, 10.0,
+                   100000.0, 0.01, 100.0, 100000.0, 100000.0, 1e-05,
+                   0.0001, 100.0, 0.0001, 1e-05, 1e-07],
+             mask=[False, False, False, False, False, False, False, False,
+                   False, False, False, False, False, False, False, False,
+                   False, False, False, False, False, False, False, False,
+                   False, False, False, False, False, False, False, False,
+                   False, False, False, False, False, False, False, False,
+                   False, False, False, False, False, False, False, False,
+                   False, False],
+       fill_value='?',
+            dtype=object), 'param_class_weight': masked_array(data=['balanced', None, 'balanced', 'balanced', 'balanced',
+                   'balanced', None, None, 'balanced', 'balanced',
+                   'balanced', None, 'balanced', None, 'balanced', None,
+                   None, None, None, 'balanced', 'balanced', 'balanced',
+                   None, 'balanced', 'balanced', 'balanced', None, None,
+                   None, None, None, None, None, 'balanced', 'balanced',
+                   'balanced', None, 'balanced', None, None, 'balanced',
+                   None, None, 'balanced', None, 'balanced', None, None,
+                   'balanced', 'balanced'],
+             mask=[False, False, False, False, False, False, False, False,
+                   False, False, False, False, False, False, False, False,
+                   False, False, False, False, False, False, False, False,
+                   False, False, False, False, False, False, False, False,
+                   False, False, False, False, False, False, False, False,
+                   False, False, False, False, False, False, False, False,
+                   False, False],
+       fill_value='?',
+            dtype=object), 'param_C': masked_array(data=[100.0, 1000.0, 1e-05, 0.001, 1000.0, 0.01, 1e-05,
+                   10000.0, 10.0, 1000.0, 0.0001, 0.1, 100000.0, 1.0,
+                   1000000.0, 1000.0, 1.0, 1000.0, 0.1, 0.001, 0.1, 0.01,
+                   1.0, 0.1, 1.0, 0.0001, 1000.0, 0.01, 1000.0, 1000000.0,
+                   1.0, 100.0, 100.0, 1e-06, 1000.0, 0.01, 0.0001, 0.1,
+                   10000.0, 0.01, 0.0001, 100000.0, 0.01, 1e-06, 10000.0,
+                   1000000.0, 1000000.0, 10.0, 1000.0, 1000.0],
+             mask=[False, False, False, False, False, False, False, False,
+                   False, False, False, False, False, False, False, False,
+                   False, False, False, False, False, False, False, False,
+                   False, False, False, False, False, False, False, False,
+                   False, False, False, False, False, False, False, False,
+                   False, False, False, False, False, False, False, False,
+                   False, False],
+       fill_value='?',
+            dtype=object), 'params': [{'tol': 0.0001, 'gamma': 10000.0, 'class_weight': 'balanced', 'C': 100.0}, {'tol': 0.0001, 'gamma': 1000.0, 'class_weight': None, 'C': 1000.0}, {'tol': 0.01, 'gamma': 100000.0, 'class_weight': 'balanced', 'C': 1e-05}, {'tol': 0.1, 'gamma': 0.01, 'class_weight': 'balanced', 'C': 0.001}, {'tol': 0.0001, 'gamma': 100000.0, 'class_weight': 'balanced', 'C': 1000.0}, {'tol': 0.1, 'gamma': 0.1, 'class_weight': 'balanced', 'C': 0.01}, {'tol': 0.001, 'gamma': 1e-08, 'class_weight': None, 'C': 1e-05}, {'tol': 0.1, 'gamma': 1000.0, 'class_weight': None, 'C': 10000.0}, {'tol': 0.1, 'gamma': 1e-05, 'class_weight': 'balanced', 'C': 10.0}, {'tol': 0.1, 'gamma': 10.0, 'class_weight': 'balanced', 'C': 1000.0}, {'tol': 0.01, 'gamma': 0.0001, 'class_weight': 'balanced', 'C': 0.0001}, {'tol': 0.0001, 'gamma': 0.1, 'class_weight': None, 'C': 0.1}, {'tol': 0.01, 'gamma': 0.01, 'class_weight': 'balanced', 'C': 100000.0}, {'tol': 0.1, 'gamma': 1e-08, 'class_weight': None, 'C': 1.0}, {'tol': 0.0001, 'gamma': 100000000.0, 'class_weight': 'balanced', 'C': 1000000.0}, {'tol': 0.1, 'gamma': 10.0, 'class_weight': None, 'C': 1000.0}, {'tol': 0.0001, 'gamma': 0.0001, 'class_weight': None, 'C': 1.0}, {'tol': 0.01, 'gamma': 0.001, 'class_weight': None, 'C': 1000.0}, {'tol': 0.0001, 'gamma': 1e-08, 'class_weight': None, 'C': 0.1}, {'tol': 0.1, 'gamma': 0.001, 'class_weight': 'balanced', 'C': 0.001}, {'tol': 0.01, 'gamma': 1e-07, 'class_weight': 'balanced', 'C': 0.1}, {'tol': 0.1, 'gamma': 100000000.0, 'class_weight': 'balanced', 'C': 0.01}, {'tol': 0.001, 'gamma': 10000000.0, 'class_weight': None, 'C': 1.0}, {'tol': 0.1, 'gamma': 100000.0, 'class_weight': 'balanced', 'C': 0.1}, {'tol': 0.01, 'gamma': 100000.0, 'class_weight': 'balanced', 'C': 1.0}, {'tol': 0.0001, 'gamma': 1e-05, 'class_weight': 'balanced', 'C': 0.0001}, {'tol': 0.01, 'gamma': 100.0, 'class_weight': None, 'C': 1000.0}, {'tol': 0.001, 'gamma': 100000.0, 'class_weight': None, 'C': 0.01}, {'tol': 0.01, 'gamma': 1e-07, 'class_weight': None, 'C': 1000.0}, {'tol': 0.01, 'gamma': 0.0001, 'class_weight': None, 'C': 1000000.0}, {'tol': 0.0001, 'gamma': 100000.0, 'class_weight': None, 'C': 1.0}, {'tol': 0.1, 'gamma': 1e-05, 'class_weight': None, 'C': 100.0}, {'tol': 0.01, 'gamma': 100000000.0, 'class_weight': None, 'C': 100.0}, {'tol': 0.1, 'gamma': 1.0, 'class_weight': 'balanced', 'C': 1e-06}, {'tol': 0.001, 'gamma': 1.0, 'class_weight': 'balanced', 'C': 1000.0}, {'tol': 0.001, 'gamma': 10000.0, 'class_weight': 'balanced', 'C': 0.01}, {'tol': 0.1, 'gamma': 0.1, 'class_weight': None, 'C': 0.0001}, {'tol': 0.01, 'gamma': 1.0, 'class_weight': 'balanced', 'C': 0.1}, {'tol': 0.0001, 'gamma': 10.0, 'class_weight': None, 'C': 10000.0}, {'tol': 0.01, 'gamma': 100000.0, 'class_weight': None, 'C': 0.01}, {'tol': 0.001, 'gamma': 0.01, 'class_weight': 'balanced', 'C': 0.0001}, {'tol': 0.01, 'gamma': 100.0, 'class_weight': None, 'C': 100000.0}, {'tol': 0.1, 'gamma': 100000.0, 'class_weight': None, 'C': 0.01}, {'tol': 0.0001, 'gamma': 100000.0, 'class_weight': 'balanced', 'C': 1e-06}, {'tol': 0.01, 'gamma': 1e-05, 'class_weight': None, 'C': 10000.0}, {'tol': 0.0001, 'gamma': 0.0001, 'class_weight': 'balanced', 'C': 1000000.0}, {'tol': 0.1, 'gamma': 100.0, 'class_weight': None, 'C': 1000000.0}, {'tol': 0.01, 'gamma': 0.0001, 'class_weight': None, 'C': 10.0}, {'tol': 0.0001, 'gamma': 1e-05, 'class_weight': 'balanced', 'C': 1000.0}, {'tol': 0.001, 'gamma': 1e-07, 'class_weight': 'balanced', 'C': 1000.0}], 'split0_test_score': array([0.10016694, 0.10016694, 0.0984975 , 0.14524207, 0.10016694,
+       0.0984975 , 0.29215359, 0.10016694, 0.94156928, 0.10016694,
+       0.19866444, 0.10016694, 0.66277129, 0.29215359, 0.10016694,
+       0.10016694, 0.94991653, 0.97161937, 0.29215359, 0.19866444,
+       0.19699499, 0.0984975 , 0.10016694, 0.0984975 , 0.10016694,
+       0.19699499, 0.10016694, 0.10016694, 0.94156928, 0.95158598,
+       0.10016694, 0.93656093, 0.10016694, 0.19866444, 0.20200334,
+       0.0984975 , 0.10016694, 0.19866444, 0.10016694, 0.10016694,
+       0.14524207, 0.10016694, 0.10016694, 0.0984975 , 0.94156928,
+       0.95158598, 0.10016694, 0.94490818, 0.93989983, 0.94156928]), 'split1_test_score': array([0.10183639, 0.10183639, 0.10016694, 0.0984975 , 0.10183639,
+       0.0984975 , 0.10183639, 0.10183639, 0.95492487, 0.10183639,
+       0.19866444, 0.10183639, 0.68948247, 0.10183639, 0.10183639,
+       0.10183639, 0.96327212, 0.98163606, 0.10183639, 0.0984975 ,
+       0.0984975 , 0.0984975 , 0.10183639, 0.0984975 , 0.10183639,
+       0.19866444, 0.10183639, 0.10183639, 0.95325543, 0.96327212,
+       0.10183639, 0.96661102, 0.10183639, 0.0984975 , 0.10183639,
+       0.0984975 , 0.10183639, 0.0984975 , 0.10183639, 0.10183639,
+       0.12687813, 0.10183639, 0.10183639, 0.0984975 , 0.95659432,
+       0.96327212, 0.10183639, 0.97161937, 0.95826377, 0.95158598]), 'split2_test_score': array([0.10183639, 0.10183639, 0.10016694, 0.0984975 , 0.10183639,
+       0.0984975 , 0.10183639, 0.10183639, 0.92654424, 0.10183639,
+       0.19866444, 0.10183639, 0.74457429, 0.10183639, 0.10183639,
+       0.10183639, 0.93155259, 0.97495826, 0.10183639, 0.0984975 ,
+       0.0984975 , 0.0984975 , 0.10183639, 0.0984975 , 0.10183639,
+       0.19866444, 0.10183639, 0.10183639, 0.92654424, 0.95158598,
+       0.10183639, 0.94156928, 0.10183639, 0.0984975 , 0.10183639,
+       0.0984975 , 0.10183639, 0.0984975 , 0.10183639, 0.10183639,
+       0.13188648, 0.10183639, 0.10183639, 0.0984975 , 0.93656093,
+       0.95158598, 0.10183639, 0.95325543, 0.93989983, 0.92654424]), 'mean_test_score': array([0.10127991, 0.10127991, 0.09961046, 0.11407902, 0.10127991,
+       0.0984975 , 0.16527546, 0.10127991, 0.9410128 , 0.10127991,
+       0.19866444, 0.10127991, 0.69894268, 0.16527546, 0.10127991,
+       0.10127991, 0.94824708, 0.97607123, 0.16527546, 0.13188648,
+       0.13132999, 0.0984975 , 0.10127991, 0.0984975 , 0.10127991,
+       0.19810796, 0.10127991, 0.10127991, 0.94045632, 0.95548136,
+       0.10127991, 0.94824708, 0.10127991, 0.13188648, 0.13522538,
+       0.0984975 , 0.10127991, 0.13188648, 0.10127991, 0.10127991,
+       0.13466889, 0.10127991, 0.10127991, 0.0984975 , 0.94490818,
+       0.95548136, 0.10127991, 0.95659432, 0.94602115, 0.93989983]), 'std_test_score': array([0.00078699, 0.00078699, 0.00078699, 0.0220356 , 0.00078699,
+       0.        , 0.08971639, 0.00078699, 0.01159303, 0.00078699,
+       0.        , 0.00078699, 0.03405931, 0.08971639, 0.00078699,
+       0.00078699, 0.01300314, 0.00416434, 0.08971639, 0.04721915,
+       0.04643216, 0.        , 0.00078699, 0.        , 0.00078699,
+       0.00078699, 0.00078699, 0.00078699, 0.01093316, 0.0055089 ,
+       0.00078699, 0.01314526, 0.00078699, 0.04721915, 0.04721915,
+       0.        , 0.00078699, 0.04721915, 0.00078699, 0.00078699,
+       0.00775091, 0.00078699, 0.00078699, 0.        , 0.00851255,
+       0.0055089 , 0.00078699, 0.01115745, 0.00865684, 0.01029118]), 'rank_test_score': array([25, 25, 45, 24, 25, 46, 15, 25,  9, 25, 13, 25, 12, 15, 25, 25,  5,
+        1, 15, 20, 23, 46, 25, 46, 25, 14, 25, 25, 10,  3, 25,  5, 25, 20,
+       18, 46, 25, 20, 25, 25, 19, 25, 25, 46,  8,  3, 25,  2,  7, 11],
+      dtype=int32)}
+
+Best Params
+{'tol': 0.01, 'gamma': 0.001, 'class_weight': None, 'C': 1000.0}
+Sleeping 2 minutes to keep job alive if you want to interact!
+```
+
+</details>
+
+If you want to debug something, you can set interactive: true to run in interactive mode, and then shell into the pod, connect to the broker:
+
+```bash
+$ kubectl exec -it -n flux-operator flux-sample-0-jlsp6 bash
+$ sudo -u fluxuser -E $(env) -E HOME=/home/fluxuser flux proxy local:///run/flux/local bash
+```
+
+For those interested, when I did this above and looked at the flux jobs submit `flux jobs -a` (to distribute the training)
+I saw that indeed, it was distributed across the workers. Notice that we are hitting all the nodes.
+
+```bash
+$ flux jobs -a
+```
+```console
+       JOBID USER     NAME       ST NTASKS NNODES     TIME INFO
+    ƒAHuVwM1 fluxuser flux-job-+  S      1      -        - 
+    ƒ9QwJdRR fluxuser flux-job-+  R      1      1   8.019s flux-sample-3
+    ƒ7ebCD4j fluxuser flux-job-+  R      1      1   12.02s flux-sample-0
+    ƒ5T6FyQj fluxuser flux-job-+  R      1      1   17.01s flux-sample-1
+    ƒ3gfhbD1 fluxuser flux-job-+  R      1      1   21.02s flux-sample-2
+    ƒ26RCHAX fluxuser flux-job-+ CD      1      1   5.370s flux-sample-3
+```
+
+### Notes
+
+#### Waiting for workers
+
+What I think I saw happening is that a first job was submit that acted as a "nanny" and this
+nanny we can ask to wait for workers (see the script). Now, these workers aren't actually the nodes, but 
+rather processes on one node (because it's launched by one job). So for that parameter I provided the number of cores.
+If you provide the number of workers (and it's more than the number of cores) you will time out!
+
+#### Submitting to Flux
+
+I did this `flux jobs -a` ultiamtely as a sanity check that dask was actually submitting jobs to Flux, and it was.
+It does seem like dask doesn't really predict how many workers it will need - it just launches them and the entire
+training finishes at some point, and the others can just hang out waiting for more work. I'm sure
+this can be tweaked. But seriously, that's so cool! 
+
+#### Cleaning Up
+
+I'm not sure about the logic of cleaning up, because when I used a branch that cleans up when a worker finishes,
+I had failed jobs that said they couldn't find the script they were supposed to run. For the time being (until
+we understand how to properly cleanup) I have commented out this line. It could be that
+the cancel command is not properly going through, or some function call on my part that we are done
+needs to happen.
+
+#### Pre-built image
+
+Finally, if you build your image with dask already installed you'll save a bit of time! I also
+would play around with the waiting time for the cluster - it likely can be shortened.
+
+### Cleanup
+
+When you are done, clean up:
+
+```bash
+$ kubectl delete -f minicluster.yaml
+```
+
+Make sure to clean up your temporary tmpdir, because something cached from a previous run could potentially interfere with
+a new one! I found that when I didn't clean up, the subsequent run timed out looking for the workers (likely because of some cache?)
+
+```bash
+$ sudo rm -rf ./tmp/*
+```

--- a/examples/machine-learning/dask/scikit-learn/launch.py
+++ b/examples/machine-learning/dask/scikit-learn/launch.py
@@ -22,9 +22,9 @@ def get_parser():
         formatter_class=argparse.RawTextHelpFormatter,
     )
     parser.add_argument("--workers", help="number of worker nodes in the cluster", type=int, default=4)
-    parser.add_argument("--cores", help="cores to give to flux cluster spec", type=int, default=2)
+    parser.add_argument("--cores", help="cores to give to flux cluster spec", type=int, default=1)
     parser.add_argument('--memory', help='dummy memory variable (is not used)', default="2GB")
-    parser.add_argument('--timeout', help='default timeout to wait for workers (20 seconds)', type=int, default=20)
+    parser.add_argument('--timeout', help='default timeout to wait for workers (60 seconds)', type=int, default=60)
     return parser
 
 
@@ -41,16 +41,13 @@ def main():
 
     # For flux, memory doesn't matter (it's ignored) and processes are the number of workers
     # (at least I think!)
-    with FluxCluster(cores=args.cores, processes=args.workers, memory=args.memory) as cluster:
+    with FluxCluster(cores=args.cores, processes=1, memory=args.memory) as cluster:
         cluster.adapt()
 
         # This creates the cluster (but we don't need to further interact with the client)
         with Client(cluster) as client:
             cluster.scale(args.workers)
-
-            # When I tested this, it seemed to just launch one job on a node, so 
-            # I would guess waiting for workers means waiting for local workers?
-            client.wait_for_workers(args.cores, timeout=args.timeout)
+            client.wait_for_workers(args.workers, timeout=args.timeout)
             digits = load_digits()
 
             param_space = {

--- a/examples/machine-learning/dask/scikit-learn/launch.py
+++ b/examples/machine-learning/dask/scikit-learn/launch.py
@@ -1,0 +1,79 @@
+import argparse
+from time import sleep
+from dask_jobqueue import FluxCluster
+from distributed import Client
+
+import numpy as np
+from dask.distributed import Client
+import dask.config
+
+import joblib
+from sklearn.datasets import load_digits
+from sklearn.model_selection import RandomizedSearchCV
+from sklearn.svm import SVC
+
+
+# Ensure the place dask writes files is shared by all nodes!
+dask.config.set(temporary_directory='/tmp/workflow/tmp')
+
+def get_parser():
+    parser = argparse.ArgumentParser(
+        description="Flux Basic Experiment Runner",
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    parser.add_argument("--workers", help="number of worker nodes in the cluster", type=int, default=4)
+    parser.add_argument("--cores", help="cores to give to flux cluster spec", type=int, default=2)
+    parser.add_argument('--memory', help='dummy memory variable (is not used)', default="2GB")
+    parser.add_argument('--timeout', help='default timeout to wait for workers (20 seconds)', type=int, default=20)
+    return parser
+
+
+def main():
+    parser = get_parser()
+
+    # If an error occurs while parsing the arguments, the interpreter will exit with value 2
+    args, _ = parser.parse_known_args()
+
+    # Show args to the user
+    print("     nodes: %s" % args.workers)
+    print("     cores: %s" % args.cores)
+    print("   timeout: %s" % args.timeout)
+
+    # For flux, memory doesn't matter (it's ignored) and processes are the number of workers
+    # (at least I think!)
+    with FluxCluster(cores=args.cores, processes=args.workers, memory=args.memory) as cluster:
+        cluster.adapt()
+
+        # This creates the cluster (but we don't need to further interact with the client)
+        with Client(cluster) as client:
+            cluster.scale(args.workers)
+
+            # When I tested this, it seemed to just launch one job on a node, so 
+            # I would guess waiting for workers means waiting for local workers?
+            client.wait_for_workers(args.cores, timeout=args.timeout)
+            digits = load_digits()
+
+            param_space = {
+                'C': np.logspace(-6, 6, 13),
+                'gamma': np.logspace(-8, 8, 17),
+                'tol': np.logspace(-4, -1, 4),
+                'class_weight': [None, 'balanced'],
+            }
+            model = SVC(kernel='rbf')
+            search = RandomizedSearchCV(model, param_space, cv=3, n_iter=50, verbose=10)
+
+            print('Fitting model...')
+            with joblib.parallel_backend('dask'):
+                search.fit(digits.data, digits.target)
+
+            print('CV Results:')
+            print(search.cv_results_)
+            print()
+            print('Best Params')
+            print(search.best_params_)
+            print('Sleeping for two minutes to keep job alive if you want to interact!')
+            sleep(120)
+
+if __name__ == "__main__":
+    main()
+

--- a/examples/machine-learning/dask/scikit-learn/minicluster.yaml
+++ b/examples/machine-learning/dask/scikit-learn/minicluster.yaml
@@ -1,0 +1,41 @@
+apiVersion: flux-framework.org/v1alpha1
+kind: MiniCluster
+metadata:
+  name: flux-sample
+  namespace: flux-operator
+spec:
+  size: 4
+  volumes:
+    data:
+      storageClass: hostpath
+      path: /tmp/workflow
+
+  containers:
+    - image: ghcr.io/rse-ops/singularity:tag-mamba
+      workingDir: /tmp/workflow
+
+      environment:
+        PYTHONPATH: /usr/lib/python3.10/site-packages
+        TMPDIR: /tmp/workflow/tmp
+
+      ports:
+        - 8786
+      command: python3 /tmp/workflow/launch.py --workers 4 --cores 2
+
+      # Dask will be submitting flux jobs for us
+      launcher: true
+
+      # Start the servers as the flux user so they own it
+      commands:
+        pre: |
+           pip install scikit-learn numpy
+           # Install my branch of dask distributed with flux integration
+           pip install git+https://github.com/researchapps/dask-jobqueue.git@add/flux-no-cleanup
+           pip install dask-ml
+
+      fluxUser:
+        name: fluxuser
+
+      volumes:
+        data:
+          path: /tmp/workflow

--- a/examples/machine-learning/dask/scikit-learn/minicluster.yaml
+++ b/examples/machine-learning/dask/scikit-learn/minicluster.yaml
@@ -30,7 +30,7 @@ spec:
         pre: |
            pip install scikit-learn numpy
            # Install my branch of dask distributed with flux integration
-           pip install git+https://github.com/researchapps/dask-jobqueue.git@add/flux-no-cleanup
+           pip install git+https://github.com/researchapps/dask-jobqueue.git@add/flux
            pip install dask-ml
 
       fluxUser:

--- a/examples/machine-learning/dask/scikit-learn/minicluster.yaml
+++ b/examples/machine-learning/dask/scikit-learn/minicluster.yaml
@@ -11,7 +11,7 @@ spec:
       path: /tmp/workflow
 
   containers:
-    - image: ghcr.io/rse-ops/singularity:tag-mamba
+    - image: ghcr.io/rse-ops/dask-scikit-learn:tag-mamba
       workingDir: /tmp/workflow
 
       environment:
@@ -24,18 +24,8 @@ spec:
 
       # Dask will be submitting flux jobs for us
       launcher: true
-
-      # Start the servers as the flux user so they own it
-      commands:
-        pre: |
-           pip install scikit-learn numpy
-           # Install my branch of dask distributed with flux integration
-           pip install git+https://github.com/researchapps/dask-jobqueue.git@add/flux
-           pip install dask-ml
-
       fluxUser:
         name: fluxuser
-
       volumes:
         data:
           path: /tmp/workflow


### PR DESCRIPTION
WIP: The pull request with the branch we are using of dask-jobqueue is here: 

https://github.com/dask/dask-jobqueue/pull/605

This also fixes a bug that if we don't add `--local` to the resource spec, flux thinks it has fewer cores than it does. This doesn't impact our previously run experiments because we always defined the number of cores.