### PR TITLE
Add/maxsize allowance

### DIFF
--- a/api/v1alpha1/minicluster_types.go
+++ b/api/v1alpha1/minicluster_types.go
@@ -553,8 +553,12 @@ func (f *MiniCluster) Validate() bool {
 	}
 
 	// If we haven't seen a MaxSize (in the status) yet, set it
+	// This needs to be the absolute max that is allowed
 	if f.Status.MaximumSize == 0 {
 		f.Status.MaximumSize = f.Spec.Size
+		if f.Spec.MaxSize > f.Spec.Size {
+			f.Status.MaximumSize = f.Spec.MaxSize
+		}
 	}
 	fmt.Printf("🤓 MiniCluster.MaximumSize %s\n", fmt.Sprint(f.Status.MaximumSize))
 

--- a/api/v1alpha1/minicluster_types.go
+++ b/api/v1alpha1/minicluster_types.go
@@ -79,6 +79,10 @@ type MiniClusterSpec struct {
 	// +optional
 	Size int32 `json:"size,omitempty"`
 
+	// MaxSize (maximum number of pods to allow scaling to)
+	// +optional
+	MaxSize int32 `json:"maxSize,omitempty"`
+
 	// Total number of CPUs being run across entire cluster
 	// +kubebuilder:default=1
 	// +default=1
@@ -536,6 +540,17 @@ func (f *MiniCluster) Validate() bool {
 	// Global (entire cluster) settings
 	fmt.Printf("🤓 MiniCluster.DeadlineSeconds %d\n", f.Spec.DeadlineSeconds)
 	fmt.Printf("🤓 MiniCluster.Size %s\n", fmt.Sprint(f.Spec.Size))
+
+	// If MaxSize is set, it must be greater than size
+	if f.Spec.MaxSize != 0 && f.Spec.MaxSize < f.Spec.Size {
+		fmt.Printf("😥️ MaxSize of cluster must be greater than size.\n")
+		return false
+	}
+
+	// If the MaxSize isn't set, ensure it's equal to the size
+	if f.Spec.MaxSize == 0 {
+		f.Spec.MaxSize = f.Spec.Size
+	}
 
 	// If we haven't seen a MaxSize (in the status) yet, set it
 	if f.Status.MaximumSize == 0 {

--- a/api/v1alpha1/swagger.json
+++ b/api/v1alpha1/swagger.json
@@ -459,6 +459,11 @@
           "default": {},
           "$ref": "#/definitions/LoggingSpec"
         },
+        "maxSize": {
+          "description": "MaxSize (maximum number of pods to allow scaling to)",
+          "type": "integer",
+          "format": "int32"
+        },
         "pod": {
           "description": "Pod spec details",
           "default": {},

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -874,6 +874,13 @@ func schema__api_v1alpha1__MiniClusterSpec(ref common.ReferenceCallback) common.
 							Format:      "int32",
 						},
 					},
+					"maxSize": {
+						SchemaProps: spec.SchemaProps{
+							Description: "MaxSize (maximum number of pods to allow scaling to)",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"tasks": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Total number of CPUs being run across entire cluster",

--- a/chart/templates/minicluster-crd.yaml
+++ b/chart/templates/minicluster-crd.yaml
@@ -309,6 +309,10 @@ spec:
                     description: Enable Zeromq logging
                     type: boolean
                 type: object
+              maxSize:
+                description: MaxSize (maximum number of pods to allow scaling to)
+                format: int32
+                type: integer
               pod:
                 description: Pod spec details
                 properties:

--- a/config/crd/bases/flux-framework.org_miniclusters.yaml
+++ b/config/crd/bases/flux-framework.org_miniclusters.yaml
@@ -313,6 +313,10 @@ spec:
                     description: Enable Zeromq logging
                     type: boolean
                 type: object
+              maxSize:
+                description: MaxSize (maximum number of pods to allow scaling to)
+                format: int32
+                type: integer
               pod:
                 description: Pod spec details
                 properties:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,3 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/flux-framework/flux-operator
-  newTag: test

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,3 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/flux-framework/flux-operator
+  newTag: test

--- a/controllers/flux/minicluster.go
+++ b/controllers/flux/minicluster.go
@@ -402,13 +402,26 @@ func generateHostlist(cluster *api.MiniCluster, size int) string {
 // generateFluxConfig creates the broker.toml file used to boostrap flux
 func generateFluxConfig(cluster *api.MiniCluster) string {
 
-	// The hosts will eventually be generated through the max size, so the cluster can expand
-	// This is currently not supported as flux will not allow hosts >> nodes
+	// The hosts are generated through the max size, so the cluster can expand
 	fqdn := fmt.Sprintf("%s.%s.svc.cluster.local", restfulServiceName, cluster.Namespace)
-	hosts := fmt.Sprintf("[%s]", generateRange(int(cluster.Spec.Size)))
+	hosts := fmt.Sprintf("[%s]", generateRange(int(cluster.Spec.MaxSize)))
 	fluxConfig := fmt.Sprintf(brokerConfigTemplate, fqdn, cluster.Name, hosts)
 	fluxConfig += "\n" + brokerArchiveSection
 	return fluxConfig
+}
+
+// getRequiredRanks figures out the quorum that should be online for the cluster to start
+func getRequiredRanks(cluster *api.MiniCluster) string {
+
+	// Use the Flux default - all ranks must be online
+	// Because our maximum size is == our starting size
+	requiredRanks := ""
+	if cluster.Spec.MaxSize == cluster.Spec.Size {
+		return requiredRanks
+	}
+	// This is the quorum - the nodes required to be online - so we can start
+	// This can be less than the MaxSize
+	return generateRange(int(cluster.Spec.Size))
 }
 
 // generateWaitScript generates the main script to start everything up!
@@ -441,6 +454,9 @@ func generateWaitScript(cluster *api.MiniCluster, containerIndex int) (string, e
 	// Ensure if we have a batch command, it gets split up
 	batchCommand := strings.Split(container.Command, "\n")
 
+	// Required quorum - might be smaller than initial list if size != maxsize
+	requiredRanks := getRequiredRanks(cluster)
+
 	// The token uuid is the same across images
 	wt := WaitTemplate{
 		FluxUser:      getFluxUser(cluster.Spec.FluxRestful.Username),
@@ -451,7 +467,7 @@ func generateWaitScript(cluster *api.MiniCluster, containerIndex int) (string, e
 		Container:     container,
 		Spec:          cluster.Spec,
 		Batch:         batchCommand,
-		RequiredRanks: "",
+		RequiredRanks: requiredRanks,
 	}
 	t, err := template.New("wait-sh").Parse(waitToStartTemplate)
 	if err != nil {

--- a/controllers/flux/templates.go
+++ b/controllers/flux/templates.go
@@ -42,7 +42,7 @@ type WaitTemplate struct {
 	Spec      api.MiniClusterSpec
 
 	// Broker initial quorum that must be online to start
-	// This will be used when the cluster MaxSize > Size, which is not supported yet
+	// This is used if the cluster MaxSize > Size
 	RequiredRanks string
 
 	// Batch commands split up

--- a/controllers/flux/templates/wait.sh
+++ b/controllers/flux/templates/wait.sh
@@ -88,7 +88,7 @@ brokerOptions="-Scron.directory=/etc/flux/system/cron.d \
 {{ if .RequiredRanks }}-Sbroker.quorum={{ .RequiredRanks }}{{ end }} \
 {{ if .Spec.Logging.Zeromq }}-Stbon.zmqdebug=1{{ end }} \
 {{ if not .Spec.Logging.Quiet }} -Slog-stderr-level={{or .Container.FluxLogLevel 6}} {{ else }} -Slog-stderr-level=0 {{ end }} \
--Slog-stderr-mode=local"
+  -Slog-stderr-mode=local"
 
 # if we are given an archive to use, load first, not required to exist
 # Note that we ask the user to dump in interactive mode - I am not

--- a/controllers/flux/templates/wait.sh
+++ b/controllers/flux/templates/wait.sh
@@ -88,7 +88,7 @@ brokerOptions="-Scron.directory=/etc/flux/system/cron.d \
 {{ if .RequiredRanks }}-Sbroker.quorum={{ .RequiredRanks }}{{ end }} \
 {{ if .Spec.Logging.Zeromq }}-Stbon.zmqdebug=1{{ end }} \
 {{ if not .Spec.Logging.Quiet }} -Slog-stderr-level={{or .Container.FluxLogLevel 6}} {{ else }} -Slog-stderr-level=0 {{ end }} \
-  -Slog-stderr-mode=local"
+-Slog-stderr-mode=local"
 
 # if we are given an archive to use, load first, not required to exist
 # Note that we ask the user to dump in interactive mode - I am not
@@ -257,6 +257,7 @@ function run_flux_restful() {
     {{ end }}{{ end }}
 
     # Shared envars across user modes
+    # For the RestFul API, we can't easily scale this up so MaxSize is largely ignored
     export FLUX_REQUIRE_AUTH=true
     export FLUX_SECRET_KEY={{ .Spec.FluxRestful.SecretKey}}
     export FLUX_NUMBER_NODES={{ .Spec.Size}}

--- a/docs/getting_started/custom-resource-definition.md
+++ b/docs/getting_started/custom-resource-definition.md
@@ -48,7 +48,11 @@ the set of containers that you describe.
 ```
 
 The size will always be the minimum number of pods that the Flux broker is required to see online
-in order to start (meaning for the time being, all of them).
+in order to start (meaning for the time being, all of them). If you've set a `maxSize` or you want to
+scale smaller, you can re-apply the CRD to scale down. Flux will see the nodes as going offline, and 
+of course you will want to be careful about the state of your cluster when you do this. If you scale
+down, you cannot go below 1 node, and if you scale up, you cannot exceed the maximum of the `size` or
+`maxsize`.
 
 ### maxSize
 

--- a/docs/getting_started/custom-resource-definition.md
+++ b/docs/getting_started/custom-resource-definition.md
@@ -50,6 +50,19 @@ the set of containers that you describe.
 The size will always be the minimum number of pods that the Flux broker is required to see online
 in order to start (meaning for the time being, all of them).
 
+### maxSize
+
+The `maxSize` variable is typically used when you want elasticity. E.g., it is the largest size of cluster that
+you would be able to scale to. This works by way of registering this many workers (fully qualified domain names)
+with the broker.toml. If you don't set this value, the maxsize will be set to the size.
+
+```yaml
+  # Number of pods to allow the MiniCluster to scale to
+  maxSize: 10
+```
+
+The `maxSize` must always be greater than the size, if set. 
+
 ### tasks
 
 The `tasks` variable under the spec is the number of tasks that each pod in the MiniCluster should be given.

--- a/docs/tutorials/scaling.md
+++ b/docs/tutorials/scaling.md
@@ -7,7 +7,29 @@ with the Flux Operator to enable it! Specifically:
 
  - We tell Flux to create a cluster at the maximum size that is possible (and the broker config sees this many nodes)
  - We update the resource spec to reflect that.
+ - The cluster cannot be smaller than 1 node, meaning only a broker.
+ - A cluster defined with an initial `size` can be scaled down (and back up) (see the [basic example](#basic-example))
+ - A cluster cannot be larger than it's original `size` or `maxSize`
+ - You are allowed to start smaller and specify a maxSize (see the [expand example](#expand-example))
+   - Your cluster will start at `size` and can go up to `maxSize`
+   - The cluster will start with the minimum number of nodes `size`
+   - You can go below the original size.
 
+
+<div class="result docutils container">
+<div class="info admonition">
+<p class="admonition-title">Note</p>
+    <p>This setup works most effectively in the container->launcher or interactive:true mode,
+where the broker is started without setting it to a scoped number of tasks for a specific command.  When you provide
+a command (not using interactive or launcher mode) the operator will prepare a "flux submit" with 
+the number of tasks available (the smaller size) and this will be the number of tasks allocated to your
+command. If you then scaled the cluster up, although the added resources might be seen by the broker or available
+for you to interact with otherwise, they won't be magically added to the command you initially ran. 
+For this reason, we suggest that scaling is done in launcher or interactive mode, or with a strategy in
+mind for what to do with the new resources.
+</p>
+</div>
+</div>
 
 ## Basic Example
 
@@ -231,3 +253,82 @@ NAME                  READY   STATUS              RESTARTS   AGE
 flux-sample-0-r2cxt   0/1     ContainerCreating   0          1s
 flux-sample-1-bxwbw   0/1     ContainerCreating   0          1s
 ```
+
+And then running!
+
+```bash
+kubectl get -n flux-operator pods
+NAME                  READY   STATUS    RESTARTS   AGE
+flux-sample-0-77tnb   1/1     Running   0          102s
+flux-sample-1-vfg7x   1/1     Running   0          102s
+```
+
+Theoretically, we can pretend that we brought up a small cluster, ran some smaller
+part of a workflow, and then needed to scale larger. Let's pretend to do that now, and change
+the size up to 4 (the MaxSize):
+
+```diff
+-  size: 2
++  size: 4
+```
+
+Apply again:
+
+```bash
+$ kubectl apply -f ./examples/scaling/expand/minicluster.yaml
+```
+
+You'll see the pods create very quickly, and come online to connect to the broker:
+
+```bash
+NAME                  READY   STATUS              RESTARTS   AGE
+flux-sample-0-fq4kn   1/1     Running             0          34s
+flux-sample-1-hx745   1/1     Running             0          34s
+flux-sample-2-gt4hs   0/1     ContainerCreating   0          2s
+flux-sample-3-ndqvm   1/1     Running             0          2s
+```
+
+We can again exec into the broker pod to inspect what resources Flux sees:
+
+```bash
+$ kubectl exec -it -n flux-operator flux-sample-0-xd2gc -- bash
+root@flux-sample-0:/code# sudo -E $(env) -E HOME=/home/flux -u flux flux proxy local:///var/run/flux/local 
+```
+
+And just like they had been there all along, we have four nodes!
+
+```bash
+$ flux resource list
+     STATE NNODES   NCORES NODELIST
+      free      4       16 flux-sample-[0-3]
+ allocated      0        0 
+      down      0        0 
+```
+
+You can then try scaling down, as we did before. The pods will terminate, and Flux will show
+the pods as down again. If you are curious, you can actually scale _lower_ than the original minimum
+size. As an example, we can change the size to 1:
+
+```diff
+-  size: 4
++  size: 1
+```
+
+Apply again:
+
+```bash
+$ kubectl apply -f ./examples/scaling/expand/minicluster.yaml
+```
+
+The broker is resilient and will actually keep running! I found this cool and surprising.
+
+```diff
+$ flux resource list
+     STATE NNODES   NCORES NODELIST
+      free      1        4 flux-sample-0
+ allocated      0        0 
+      down      3       12 flux-sample-[1-3]
+```
+
+Of course, the operator will not let you scale to a size 0, as that would be deleting the jobs.
+if you want to delete the MiniCluster, just do that. :)

--- a/docs/tutorials/scaling.md
+++ b/docs/tutorials/scaling.md
@@ -173,3 +173,61 @@ $ flux resource list
 
 We will have a tutorial for expanding a cluster size soon. Flux doesn't allow
 the hosts to be greater than nodes currently, so we haven't added this yet.
+
+## Expand Example
+
+> Starting with a small cluster that is able to grow to a maximum size
+
+ **[Tutorial File](https://github.com/flux-framework/flux-operator/blob/main/examples/scaling/expand/minicluster.yaml)**
+
+To run this example:
+
+```bash
+$ minikube start --kubernetes-version=1.27.
+```
+
+Install the operator, create the namespace, and create the MiniCluster:
+
+```bash
+$ kubectl apply -f ./examples/dist/flux-operator.yaml
+$ kubectl create namespace flux-operator
+$ kubectl apply -f examples/scaling/basic/minicluster.yaml
+```
+
+### Create the cluster
+
+First, apply the CRD to create the MiniCluster. Note that we are asking for a size of 2, but allowing
+for a maximum size of 4. 
+
+```yaml
+apiVersion: flux-framework.org/v1alpha1
+kind: MiniCluster
+metadata:
+  name: flux-sample
+  namespace: flux-operator
+spec:
+  # Number of pods to create for MiniCluster to start
+  size: 2
+
+  # Number of pods to allow scaling to (the number that flux will see)
+  maxSize: 4
+
+  # This needs to be in interactive or launcher mode to work
+  # otherwise we submit as a job (and it will be running under the smaller size number of tasks)
+  interactive: true
+
+  # This is a list because a pod can support multiple containers
+  containers:
+    - image: ghcr.io/flux-framework/flux-restful-api:latest
+```
+```bash
+$ kubectl apply -f ./examples/scaling/expand/minicluster.yaml
+```
+Since our initial size is 2, you'll see two pods creating:
+
+```bash
+kubectl get -n flux-operator pods
+NAME                  READY   STATUS              RESTARTS   AGE
+flux-sample-0-r2cxt   0/1     ContainerCreating   0          1s
+flux-sample-1-bxwbw   0/1     ContainerCreating   0          1s
+```

--- a/examples/dist/flux-operator.yaml
+++ b/examples/dist/flux-operator.yaml
@@ -319,6 +319,10 @@ spec:
                     description: Enable Zeromq logging
                     type: boolean
                 type: object
+              maxSize:
+                description: MaxSize (maximum number of pods to allow scaling to)
+                format: int32
+                type: integer
               pod:
                 description: Pod spec details
                 properties:

--- a/examples/scaling/expand/minicluster.yaml
+++ b/examples/scaling/expand/minicluster.yaml
@@ -1,0 +1,19 @@
+apiVersion: flux-framework.org/v1alpha1
+kind: MiniCluster
+metadata:
+  name: flux-sample
+  namespace: flux-operator
+spec:
+  # Number of pods to create for MiniCluster to start
+  size: 2
+
+  # Number of pods to allow scaling to (the number that flux will see)
+  maxSize: 4
+
+  # This needs to be in interactive or launcher mode to work
+  # otherwise we submit as a job (and it will be running under the smaller size number of tasks)
+  interactive: true
+
+  # This is a list because a pod can support multiple containers
+  containers:
+    - image: ghcr.io/flux-framework/flux-restful-api:latest

--- a/sdk/python/v1alpha1/CHANGELOG.md
+++ b/sdk/python/v1alpha1/CHANGELOG.md
@@ -15,6 +15,7 @@ The versions coincide with releases on pip. Only major versions will be released
 
 ## [0.0.x](https://github.com/flux-framework/flux-operator/tree/main/sdk/python/v2alpha1) (0.0.x)
  - add status size variable (0.0.22)
+   - support maxSize to allow cluster scaling
  - support for staging (batchRaw) and batch submit (0.0.21)
  - tweak deletion logic to allow 404 response from get pods (0.0.2)
  - refactor of FluxOperator to include FluxMiniCluster to wrap it (0.0.19)

--- a/sdk/python/v1alpha1/docs/MiniClusterSpec.md
+++ b/sdk/python/v1alpha1/docs/MiniClusterSpec.md
@@ -12,6 +12,7 @@ Name | Type | Description | Notes
 **interactive** | **bool** | Run a single-user, interactive minicluster | [optional] [default to False]
 **job_labels** | **dict(str, str)** | Labels for the job | [optional] 
 **logging** | [**LoggingSpec**](LoggingSpec.md) |  | [optional] 
+**max_size** | **int** | MaxSize (maximum number of pods to allow scaling to) | [optional] 
 **pod** | [**PodSpec**](PodSpec.md) |  | [optional] 
 **services** | [**list[MiniClusterContainer]**](MiniClusterContainer.md) | Services are one or more service containers to bring up alongside the MiniCluster. | [optional] 
 **size** | **int** | Size (number of job pods to run, size of minicluster in pods) This is also the minimum number required to start Flux | [optional] [default to 1]

--- a/sdk/python/v1alpha1/fluxoperator/models/mini_cluster_spec.py
+++ b/sdk/python/v1alpha1/fluxoperator/models/mini_cluster_spec.py
@@ -41,6 +41,7 @@ class MiniClusterSpec(object):
         'interactive': 'bool',
         'job_labels': 'dict(str, str)',
         'logging': 'LoggingSpec',
+        'max_size': 'int',
         'pod': 'PodSpec',
         'services': 'list[MiniClusterContainer]',
         'size': 'int',
@@ -58,6 +59,7 @@ class MiniClusterSpec(object):
         'interactive': 'interactive',
         'job_labels': 'jobLabels',
         'logging': 'logging',
+        'max_size': 'maxSize',
         'pod': 'pod',
         'services': 'services',
         'size': 'size',
@@ -66,7 +68,7 @@ class MiniClusterSpec(object):
         'volumes': 'volumes'
     }
 
-    def __init__(self, archive=None, cleanup=False, containers=None, deadline_seconds=31500000, flux_restful=None, interactive=False, job_labels=None, logging=None, pod=None, services=None, size=1, tasks=1, users=None, volumes=None, local_vars_configuration=None):  # noqa: E501
+    def __init__(self, archive=None, cleanup=False, containers=None, deadline_seconds=31500000, flux_restful=None, interactive=False, job_labels=None, logging=None, max_size=None, pod=None, services=None, size=1, tasks=1, users=None, volumes=None, local_vars_configuration=None):  # noqa: E501
         """MiniClusterSpec - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration.get_default_copy()
@@ -80,6 +82,7 @@ class MiniClusterSpec(object):
         self._interactive = None
         self._job_labels = None
         self._logging = None
+        self._max_size = None
         self._pod = None
         self._services = None
         self._size = None
@@ -103,6 +106,8 @@ class MiniClusterSpec(object):
             self.job_labels = job_labels
         if logging is not None:
             self.logging = logging
+        if max_size is not None:
+            self.max_size = max_size
         if pod is not None:
             self.pod = pod
         if services is not None:
@@ -295,6 +300,29 @@ class MiniClusterSpec(object):
         """
 
         self._logging = logging
+
+    @property
+    def max_size(self):
+        """Gets the max_size of this MiniClusterSpec.  # noqa: E501
+
+        MaxSize (maximum number of pods to allow scaling to)  # noqa: E501
+
+        :return: The max_size of this MiniClusterSpec.  # noqa: E501
+        :rtype: int
+        """
+        return self._max_size
+
+    @max_size.setter
+    def max_size(self, max_size):
+        """Sets the max_size of this MiniClusterSpec.
+
+        MaxSize (maximum number of pods to allow scaling to)  # noqa: E501
+
+        :param max_size: The max_size of this MiniClusterSpec.  # noqa: E501
+        :type max_size: int
+        """
+
+        self._max_size = max_size
 
     @property
     def pod(self):


### PR DESCRIPTION
This will allow the cluster to start at a much smaller size, and allow the user to define a `maxSize` in the CRD, and then scale the cluster up to it. I've added notes in the scaling tutorial page about the modes this is most appropriate to do (launcher and interactive, where we don't scope a command to a smaller number of tasks).