### PR TITLE
add support for custom flux install

### DIFF
--- a/api/v1alpha1/minicluster_types.go
+++ b/api/v1alpha1/minicluster_types.go
@@ -306,6 +306,11 @@ type ContainerVolume struct {
 
 type FluxSpec struct {
 
+	// Install root location
+	// +kubebuilder:default="/usr"
+	// +default="/usr"
+	InstallRoot string `json:"installRoot,omitempty"`
+
 	// Single user executable to provide to flux start
 	// +kubebuilder:default="5s"
 	// +default="5s"
@@ -545,6 +550,15 @@ func (f *MiniCluster) ExistingVolumes() map[string]MiniClusterExistingVolume {
 	return volumes
 }
 
+// fluxInstallRoot returns the flux install root
+func (f *MiniCluster) FluxInstallRoot() string {
+	root := f.Spec.Flux.InstallRoot
+	if root == "" {
+		root = "/usr"
+	}
+	return root
+}
+
 // Validate ensures we have data that is needed, and sets defaults if needed
 func (f *MiniCluster) Validate() bool {
 	fmt.Println()
@@ -557,6 +571,11 @@ func (f *MiniCluster) Validate() bool {
 	if f.Spec.MaxSize != 0 && f.Spec.MaxSize < f.Spec.Size {
 		fmt.Printf("😥️ MaxSize of cluster must be greater than size.\n")
 		return false
+	}
+
+	// Set the Flux install root
+	if f.Spec.Flux.InstallRoot == "" {
+		f.Spec.Flux.InstallRoot = "/usr"
 	}
 
 	// If the MaxSize isn't set, ensure it's equal to the size

--- a/api/v1alpha1/swagger.json
+++ b/api/v1alpha1/swagger.json
@@ -123,6 +123,11 @@
           "type": "string",
           "default": "5s"
         },
+        "installRoot": {
+          "description": "Install root location",
+          "type": "string",
+          "default": "/usr"
+        },
         "logLevel": {
           "description": "Log level to use for flux logging (only in non TestMode)",
           "type": "integer",

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -243,6 +243,14 @@ func schema__api_v1alpha1__FluxSpec(ref common.ReferenceCallback) common.OpenAPI
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
+					"installRoot": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Install root location",
+							Default:     "/usr",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"connectTimeout": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Single user executable to provide to flux start",

--- a/chart/templates/minicluster-crd.yaml
+++ b/chart/templates/minicluster-crd.yaml
@@ -245,6 +245,10 @@ spec:
                     default: 5s
                     description: Single user executable to provide to flux start
                     type: string
+                  installRoot:
+                    default: /usr
+                    description: Install root location
+                    type: string
                   logLevel:
                     default: 6
                     description: Log level to use for flux logging (only in non TestMode)

--- a/config/crd/bases/flux-framework.org_miniclusters.yaml
+++ b/config/crd/bases/flux-framework.org_miniclusters.yaml
@@ -247,6 +247,10 @@ spec:
                     default: 5s
                     description: Single user executable to provide to flux start
                     type: string
+                  installRoot:
+                    default: /usr
+                    description: Install root location
+                    type: string
                   logLevel:
                     default: 6
                     description: Log level to use for flux logging (only in non TestMode)

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,3 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/flux-framework/flux-operator
-  newTag: test

--- a/controllers/flux/minicluster.go
+++ b/controllers/flux/minicluster.go
@@ -417,7 +417,7 @@ func generateFluxConfig(cluster *api.MiniCluster) string {
 	// The hosts are generated through the max size, so the cluster can expand
 	fqdn := fmt.Sprintf("%s.%s.svc.cluster.local", restfulServiceName, cluster.Namespace)
 	hosts := fmt.Sprintf("[%s]", generateRange(int(cluster.Spec.MaxSize)))
-	fluxConfig := fmt.Sprintf(brokerConfigTemplate, fqdn, cluster.Name, hosts)
+	fluxConfig := fmt.Sprintf(brokerConfigTemplate, cluster.FluxInstallRoot(), fqdn, cluster.Name, hosts)
 	fluxConfig += "\n" + brokerArchiveSection
 	return fluxConfig
 }

--- a/controllers/flux/templates/broker.toml
+++ b/controllers/flux/templates/broker.toml
@@ -1,6 +1,6 @@
 # Flux needs to know the path to the IMP executable
 [exec]
-imp = "/usr/libexec/flux/flux-imp"
+imp = "%s/libexec/flux/flux-imp"
 
 [access]
 allow-guest-user = true

--- a/docs/getting_started/custom-resource-definition.md
+++ b/docs/getting_started/custom-resource-definition.md
@@ -323,6 +323,26 @@ flux:
   logLevel: 7
 ```
 
+#### installRoot
+
+We traditionally install flux to `/usr`, however you might have a container
+with a non-traditional install location! You can edit this with the flux->installRoot
+directive:
+
+```yaml
+flux:
+  installRoot: /usr/local
+```
+
+Or for a spack container, with a view at `/opt/view`:
+
+```yaml
+flux:
+  installRoot: /opt/view
+```
+
+Note that the operator will still create assets for flux at `/etc/flux`.
+
 #### connectTimeout
 
 For Flux versions 0.50.0 and later, you can customize the zeromq timeout. This is done

--- a/examples/dist/flux-operator.yaml
+++ b/examples/dist/flux-operator.yaml
@@ -253,6 +253,10 @@ spec:
                     default: 5s
                     description: Single user executable to provide to flux start
                     type: string
+                  installRoot:
+                    default: /usr
+                    description: Install root location
+                    type: string
                   logLevel:
                     default: 6
                     description: Log level to use for flux logging (only in non TestMode)

--- a/hack/python-sdk/template/setup.py
+++ b/hack/python-sdk/template/setup.py
@@ -30,7 +30,7 @@ except Exception:
 if __name__ == "__main__":
     setup(
         name="fluxoperator",
-        version="0.0.22",
+        version="0.0.23",
         author="Vanessasaurus",
         author_email="vsoch@users.noreply.github.com",
         maintainer="Vanessasaurus",

--- a/sdk/python/v1alpha1/.openapi-generator/FILES
+++ b/sdk/python/v1alpha1/.openapi-generator/FILES
@@ -53,13 +53,4 @@ setup.cfg
 setup.py
 test-requirements.txt
 test/__init__.py
-test/test_mini_cluster.py
-test/test_mini_cluster_archive.py
-test/test_mini_cluster_container.py
-test/test_mini_cluster_existing_volume.py
-test/test_mini_cluster_list.py
-test/test_mini_cluster_spec.py
-test/test_mini_cluster_status.py
-test/test_mini_cluster_user.py
-test/test_mini_cluster_volume.py
 tox.ini

--- a/sdk/python/v1alpha1/CHANGELOG.md
+++ b/sdk/python/v1alpha1/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/flux-framework/flux-operator/tree/main/sdk/python/v2alpha1) (0.0.x)
+ - custom installRoot for flux (0.0.23)
  - add status size variable (0.0.22)
    - support maxSize to allow cluster scaling
  - support for staging (batchRaw) and batch submit (0.0.21)

--- a/sdk/python/v1alpha1/docs/FluxSpec.md
+++ b/sdk/python/v1alpha1/docs/FluxSpec.md
@@ -5,6 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **connect_timeout** | **str** | Single user executable to provide to flux start | [optional] [default to '5s']
+**install_root** | **str** | Install root location | [optional] [default to '/usr']
 **log_level** | **int** | Log level to use for flux logging (only in non TestMode) | [optional] [default to 6]
 **option_flags** | **str** | Flux option flags, usually provided with -o optional - if needed, default option flags for the server These can also be set in the user interface to override here. This is only valid for a FluxRunner \&quot;runFlux\&quot; true | [optional] [default to '']
 

--- a/sdk/python/v1alpha1/fluxoperator/models/flux_spec.py
+++ b/sdk/python/v1alpha1/fluxoperator/models/flux_spec.py
@@ -34,29 +34,34 @@ class FluxSpec(object):
     """
     openapi_types = {
         'connect_timeout': 'str',
+        'install_root': 'str',
         'log_level': 'int',
         'option_flags': 'str'
     }
 
     attribute_map = {
         'connect_timeout': 'connectTimeout',
+        'install_root': 'installRoot',
         'log_level': 'logLevel',
         'option_flags': 'optionFlags'
     }
 
-    def __init__(self, connect_timeout='5s', log_level=6, option_flags='', local_vars_configuration=None):  # noqa: E501
+    def __init__(self, connect_timeout='5s', install_root='/usr', log_level=6, option_flags='', local_vars_configuration=None):  # noqa: E501
         """FluxSpec - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._connect_timeout = None
+        self._install_root = None
         self._log_level = None
         self._option_flags = None
         self.discriminator = None
 
         if connect_timeout is not None:
             self.connect_timeout = connect_timeout
+        if install_root is not None:
+            self.install_root = install_root
         if log_level is not None:
             self.log_level = log_level
         if option_flags is not None:
@@ -84,6 +89,29 @@ class FluxSpec(object):
         """
 
         self._connect_timeout = connect_timeout
+
+    @property
+    def install_root(self):
+        """Gets the install_root of this FluxSpec.  # noqa: E501
+
+        Install root location  # noqa: E501
+
+        :return: The install_root of this FluxSpec.  # noqa: E501
+        :rtype: str
+        """
+        return self._install_root
+
+    @install_root.setter
+    def install_root(self, install_root):
+        """Sets the install_root of this FluxSpec.
+
+        Install root location  # noqa: E501
+
+        :param install_root: The install_root of this FluxSpec.  # noqa: E501
+        :type install_root: str
+        """
+
+        self._install_root = install_root
 
     @property
     def log_level(self):

--- a/sdk/python/v1alpha1/setup.py
+++ b/sdk/python/v1alpha1/setup.py
@@ -30,7 +30,7 @@ except Exception:
 if __name__ == "__main__":
     setup(
         name="fluxoperator",
-        version="0.0.22",
+        version="0.0.23",
         author="Vanessasaurus",
         author_email="vsoch@users.noreply.github.com",
         maintainer="Vanessasaurus",


### PR DESCRIPTION
flux is normally found on the path, but in the case of the hard coded paths for the imp and other associated files, we should allow the minicluster crd to customize the location.

This will close #166 