### PR TITLE
unique label for hpa selector

### DIFF
--- a/controllers/flux/job.go
+++ b/controllers/flux/job.go
@@ -30,6 +30,11 @@ func (r *MiniClusterReconciler) newMiniClusterJob(
 	podLabels := r.getPodLabels(cluster)
 	setAsFQDN := false
 
+	// We add the selector for the horizontal auto scaler, if active
+	// We can't use the job-name selector, as this would include the
+	// external sidecar service!
+	podLabels["hpa-selector"] = cluster.Name
+
 	// This is an indexed-job
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/flux/minicluster.go
+++ b/controllers/flux/minicluster.go
@@ -116,7 +116,7 @@ func (r *MiniClusterReconciler) ensureMiniCluster(
 	// This would be done via a request to a running metrics server
 	// If there is no autoscaler, has no impact. The .Status.Size
 	// should already be updated via the function above.
-	result, err = r.addScaleSelector(ctx, selector, cluster)
+	result, err = r.addScaleSelector(ctx, cluster)
 	if err != nil {
 		return result, err
 	}

--- a/controllers/flux/scale.go
+++ b/controllers/flux/scale.go
@@ -26,12 +26,11 @@ import (
 // is updated later.
 func (r *MiniClusterReconciler) addScaleSelector(
 	ctx context.Context,
-	labels map[string]string,
 	cluster *api.MiniCluster,
 ) (ctrl.Result, error) {
 
 	// Update the pod selector to allow horizontal autoscaling
-	selector := "job-name=" + labels["job-name"]
+	selector := "hpa-selector=" + cluster.Name
 	if cluster.Status.Selector == selector {
 		r.log.Info("MiniCluster", "ScaleSelector", selector, "Status", "Ready")
 		return ctrl.Result{}, nil

--- a/examples/elasticity/horizontal-autoscaler/minicluster.yaml
+++ b/examples/elasticity/horizontal-autoscaler/minicluster.yaml
@@ -14,10 +14,9 @@ spec:
       workingDir: /data
 
       # We will use launcher here to just run the command
+      # You can shell in to connect to the broker and issue commands that use CPU
       launcher: true
-
-      # This is me making bad life choices
-      command: /bin/bash -c "sleep 10 && openssl speed -multi 2"
+      command: sleep infinity
 
       # Important! We need to have resource requests for the horizonal autoscaler
       # The Flux Operator doesn't know you want to use it, so it's up to you

--- a/sdk/python/v1alpha1/setup.py
+++ b/sdk/python/v1alpha1/setup.py
@@ -30,7 +30,7 @@ except Exception:
 if __name__ == "__main__":
     setup(
         name="fluxoperator",
-        version="0.0.25",
+        version="0.0.26",
         author="Vanessasaurus",
         author_email="vsoch@users.noreply.github.com",
         maintainer="Vanessasaurus",


### PR DESCRIPTION
we are currently using the headless service label, which is not ideal because we would include the pod for a sidecar service! This update will use a separate hpa-selector label instead, which will only select for the pods within the indexed job of the named minicluster