### PR TITLE
support for minicluster finished status

### DIFF
--- a/api/v1alpha1/minicluster_types.go
+++ b/api/v1alpha1/minicluster_types.go
@@ -197,6 +197,10 @@ type MiniClusterStatus struct {
 	Size     int32  `json:"size"`
 	Selector string `json:"selector"`
 
+	// Label to indicate that job is completed, comes from Job.Completed
+	// The user can also look at conditions -> JobFinished
+	Completed bool `json:"completed"`
+
 	// The Jobid is set internally to associate to a miniCluster
 	// This isn't currently in use, we only have one!
 	Jobid string `json:"jobid"`

--- a/api/v1alpha1/minicluster_types.go
+++ b/api/v1alpha1/minicluster_types.go
@@ -199,6 +199,7 @@ type MiniClusterStatus struct {
 
 	// Label to indicate that job is completed, comes from Job.Completed
 	// The user can also look at conditions -> JobFinished
+	// +optional
 	Completed bool `json:"completed"`
 
 	// The Jobid is set internally to associate to a miniCluster

--- a/api/v1alpha1/swagger.json
+++ b/api/v1alpha1/swagger.json
@@ -562,10 +562,16 @@
       "required": [
         "size",
         "selector",
+        "completed",
         "jobid",
         "maximumSize"
       ],
       "properties": {
+        "completed": {
+          "description": "Label to indicate that job is completed, comes from Job.Completed The user can also look at conditions -\u003e JobFinished",
+          "type": "boolean",
+          "default": false
+        },
         "conditions": {
           "description": "conditions hold the latest Flux Job and MiniCluster states",
           "type": "array",

--- a/api/v1alpha1/swagger.json
+++ b/api/v1alpha1/swagger.json
@@ -562,7 +562,6 @@
       "required": [
         "size",
         "selector",
-        "completed",
         "jobid",
         "maximumSize"
       ],

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -1024,6 +1024,14 @@ func schema__api_v1alpha1__MiniClusterStatus(ref common.ReferenceCallback) commo
 							Format:  "",
 						},
 					},
+					"completed": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Label to indicate that job is completed, comes from Job.Completed The user can also look at conditions -> JobFinished",
+							Default:     false,
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"jobid": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The Jobid is set internally to associate to a miniCluster This isn't currently in use, we only have one!",
@@ -1060,7 +1068,7 @@ func schema__api_v1alpha1__MiniClusterStatus(ref common.ReferenceCallback) commo
 						},
 					},
 				},
-				Required: []string{"size", "selector", "jobid", "maximumSize"},
+				Required: []string{"size", "selector", "completed", "jobid", "maximumSize"},
 			},
 		},
 		Dependencies: []string{

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -1068,7 +1068,7 @@ func schema__api_v1alpha1__MiniClusterStatus(ref common.ReferenceCallback) commo
 						},
 					},
 				},
-				Required: []string{"size", "selector", "completed", "jobid", "maximumSize"},
+				Required: []string{"size", "selector", "jobid", "maximumSize"},
 			},
 		},
 		Dependencies: []string{

--- a/chart/templates/minicluster-crd.yaml
+++ b/chart/templates/minicluster-crd.yaml
@@ -765,7 +765,6 @@ spec:
                 format: int32
                 type: integer
             required:
-            - completed
             - jobid
             - maximumSize
             - selector

--- a/chart/templates/minicluster-crd.yaml
+++ b/chart/templates/minicluster-crd.yaml
@@ -675,6 +675,10 @@ spec:
           status:
             description: MiniClusterStatus defines the observed state of Flux
             properties:
+              completed:
+                description: Label to indicate that job is completed, comes from Job.Completed
+                  The user can also look at conditions -> JobFinished
+                type: boolean
               conditions:
                 description: conditions hold the latest Flux Job and MiniCluster states
                 items:
@@ -761,6 +765,7 @@ spec:
                 format: int32
                 type: integer
             required:
+            - completed
             - jobid
             - maximumSize
             - selector

--- a/config/crd/bases/flux-framework.org_miniclusters.yaml
+++ b/config/crd/bases/flux-framework.org_miniclusters.yaml
@@ -682,6 +682,10 @@ spec:
           status:
             description: MiniClusterStatus defines the observed state of Flux
             properties:
+              completed:
+                description: Label to indicate that job is completed, comes from Job.Completed
+                  The user can also look at conditions -> JobFinished
+                type: boolean
               conditions:
                 description: conditions hold the latest Flux Job and MiniCluster states
                 items:
@@ -768,6 +772,7 @@ spec:
                 format: int32
                 type: integer
             required:
+            - completed
             - jobid
             - maximumSize
             - selector

--- a/config/crd/bases/flux-framework.org_miniclusters.yaml
+++ b/config/crd/bases/flux-framework.org_miniclusters.yaml
@@ -772,7 +772,6 @@ spec:
                 format: int32
                 type: integer
             required:
-            - completed
             - jobid
             - maximumSize
             - selector

--- a/controllers/flux/minicluster.go
+++ b/controllers/flux/minicluster.go
@@ -158,13 +158,15 @@ func (r *MiniClusterReconciler) ensureMiniCluster(
 	}
 
 	// Determine if the job is completed, and flag the MiniCluster
-	if jobctrl.IsFinished(mc) && status != jobctrl.ConditionJobFinished {
-		r.log.Info("MiniCluster", "Status", "Finished")
-		cluster.Status.Completed = true
-		clusterCopy := cluster.DeepCopy()
-		jobctrl.FlagConditionFinished(clusterCopy)
-		r.Status().Update(ctx, clusterCopy)
+	if !cluster.Status.Completed {
+		if jobctrl.IsFinished(mc) {
+			cluster.Status.Completed = true
+			clusterCopy := cluster.DeepCopy()
+			jobctrl.FlagConditionFinished(clusterCopy)
+			r.Status().Update(ctx, clusterCopy)
+		}
 	}
+
 	// And we re-queue so the Ready condition triggers next steps!
 	return ctrl.Result{Requeue: true}, nil
 }

--- a/controllers/flux/minicluster.go
+++ b/controllers/flux/minicluster.go
@@ -160,6 +160,7 @@ func (r *MiniClusterReconciler) ensureMiniCluster(
 	// Determine if the job is completed, and flag the MiniCluster
 	if jobctrl.IsFinished(mc) && status != jobctrl.ConditionJobFinished {
 		r.log.Info("MiniCluster", "Status", "Finished")
+		cluster.Status.Completed = true
 		clusterCopy := cluster.DeepCopy()
 		jobctrl.FlagConditionFinished(clusterCopy)
 		r.Status().Update(ctx, clusterCopy)

--- a/controllers/flux/minicluster.go
+++ b/controllers/flux/minicluster.go
@@ -157,6 +157,13 @@ func (r *MiniClusterReconciler) ensureMiniCluster(
 		r.Status().Update(ctx, clusterCopy)
 	}
 
+	// Determine if the job is completed, and flag the MiniCluster
+	if jobctrl.IsFinished(mc) && status != jobctrl.ConditionJobFinished {
+		r.log.Info("MiniCluster", "Status", "Finished")
+		clusterCopy := cluster.DeepCopy()
+		jobctrl.FlagConditionFinished(clusterCopy)
+		r.Status().Update(ctx, clusterCopy)
+	}
 	// And we re-queue so the Ready condition triggers next steps!
 	return ctrl.Result{Requeue: true}, nil
 }

--- a/examples/dist/flux-operator.yaml
+++ b/examples/dist/flux-operator.yaml
@@ -688,6 +688,10 @@ spec:
           status:
             description: MiniClusterStatus defines the observed state of Flux
             properties:
+              completed:
+                description: Label to indicate that job is completed, comes from Job.Completed
+                  The user can also look at conditions -> JobFinished
+                type: boolean
               conditions:
                 description: conditions hold the latest Flux Job and MiniCluster states
                 items:
@@ -774,6 +778,7 @@ spec:
                 format: int32
                 type: integer
             required:
+            - completed
             - jobid
             - maximumSize
             - selector

--- a/examples/dist/flux-operator.yaml
+++ b/examples/dist/flux-operator.yaml
@@ -778,7 +778,6 @@ spec:
                 format: int32
                 type: integer
             required:
-            - completed
             - jobid
             - maximumSize
             - selector

--- a/pkg/job/conditions.go
+++ b/pkg/job/conditions.go
@@ -32,7 +32,7 @@ const (
 	//     Resources are created, and status is switched from Waiting -> Running by MiniCluster
 	//     This should be when we kick off the command. The job is running
 	// Finished:
-	//     When resources are done (TBA how determined)
+	//     When resources are done
 	// Finished the job is finished running!
 	ConditionJobRequested string = "JobRequested"
 	ConditionJobWaiting   string = "JobWaitingForResources"

--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -13,6 +13,9 @@ package job
 import (
 	api "flux-framework/flux-operator/api/v1alpha1"
 
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/mitchellh/hashstructure/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -118,13 +121,12 @@ func FlagConditionFinished(job *api.MiniCluster) {
 	UpdateCondition(job, ConditionJobFinished)
 }
 
-// TODO here is how we determed if a batch job was successful / not
-// I'm not sure yet where batch fits in, but maybe...
-/*func IsFinished(job *api.MiniCluster) (batchv1.JobConditionType, bool) {
-	for _, c := range j.Status.Conditions {
-		if (c.Type == batchv1.JobComplete || c.Type == batchv1.JobFailed) && c.Status == corev1.ConditionTrue {
-			return c.Type, true
+// Determine if the job is finished
+func IsFinished(job *batchv1.Job) bool {
+	for _, condition := range job.Status.Conditions {
+		if condition.Type == "Complete" {
+			return condition.Status == corev1.ConditionTrue
 		}
 	}
-	return "", false
-}*/
+	return false
+}

--- a/sdk/python/v1alpha1/docs/MiniClusterStatus.md
+++ b/sdk/python/v1alpha1/docs/MiniClusterStatus.md
@@ -5,7 +5,7 @@ MiniClusterStatus defines the observed state of Flux
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**completed** | **bool** | Label to indicate that job is completed, comes from Job.Completed The user can also look at conditions -&gt; JobFinished | [default to False]
+**completed** | **bool** | Label to indicate that job is completed, comes from Job.Completed The user can also look at conditions -&gt; JobFinished | [optional] [default to False]
 **conditions** | [**list[V1Condition]**](V1Condition.md) | conditions hold the latest Flux Job and MiniCluster states | [optional] 
 **jobid** | **str** | The Jobid is set internally to associate to a miniCluster This isn&#39;t currently in use, we only have one! | [default to '']
 **maximum_size** | **int** | We keep the original size of the MiniCluster request as this is the absolute maximum | [default to 0]

--- a/sdk/python/v1alpha1/docs/MiniClusterStatus.md
+++ b/sdk/python/v1alpha1/docs/MiniClusterStatus.md
@@ -5,6 +5,7 @@ MiniClusterStatus defines the observed state of Flux
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**completed** | **bool** | Label to indicate that job is completed, comes from Job.Completed The user can also look at conditions -&gt; JobFinished | [default to False]
 **conditions** | [**list[V1Condition]**](V1Condition.md) | conditions hold the latest Flux Job and MiniCluster states | [optional] 
 **jobid** | **str** | The Jobid is set internally to associate to a miniCluster This isn&#39;t currently in use, we only have one! | [default to '']
 **maximum_size** | **int** | We keep the original size of the MiniCluster request as this is the absolute maximum | [default to 0]

--- a/sdk/python/v1alpha1/fluxoperator/client.py
+++ b/sdk/python/v1alpha1/fluxoperator/client.py
@@ -24,7 +24,7 @@ class FluxMiniCluster:
     Each MiniCluster holds it's own controller for the Flux Operator.
     """
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         """
         Create a persistent client to interact with a MiniCluster
 
@@ -34,7 +34,7 @@ class FluxMiniCluster:
         self.metadata = None
         self._pods = None
         self._broker_pod = None
-        self.ctrl = FluxOperator()
+        self.ctrl = FluxOperator(**kwargs)
 
     def load(self, metadata):
         """
@@ -210,13 +210,13 @@ class FluxBrokerMiniCluster(FluxMiniCluster):
 
 
 class FluxOperator:
-    def __init__(self, namespace=None):
+    def __init__(self, namespace=None, **kwargs):
         """
         Create a persistent client to interact with a MiniCluster
 
         This currently assumes the namespace exists.
         """
-        self._core_v1 = None
+        self._core_v1 = kwargs.get('core_v1_api')
         self.namespace = namespace
 
     @property

--- a/sdk/python/v1alpha1/fluxoperator/models/mini_cluster_status.py
+++ b/sdk/python/v1alpha1/fluxoperator/models/mini_cluster_status.py
@@ -64,7 +64,8 @@ class MiniClusterStatus(object):
         self._size = None
         self.discriminator = None
 
-        self.completed = completed
+        if completed is not None:
+            self.completed = completed
         if conditions is not None:
             self.conditions = conditions
         self.jobid = jobid
@@ -92,8 +93,6 @@ class MiniClusterStatus(object):
         :param completed: The completed of this MiniClusterStatus.  # noqa: E501
         :type completed: bool
         """
-        if self.local_vars_configuration.client_side_validation and completed is None:  # noqa: E501
-            raise ValueError("Invalid value for `completed`, must not be `None`")  # noqa: E501
 
         self._completed = completed
 

--- a/sdk/python/v1alpha1/fluxoperator/models/mini_cluster_status.py
+++ b/sdk/python/v1alpha1/fluxoperator/models/mini_cluster_status.py
@@ -33,6 +33,7 @@ class MiniClusterStatus(object):
                             and the value is json key in definition.
     """
     openapi_types = {
+        'completed': 'bool',
         'conditions': 'list[V1Condition]',
         'jobid': 'str',
         'maximum_size': 'int',
@@ -41,6 +42,7 @@ class MiniClusterStatus(object):
     }
 
     attribute_map = {
+        'completed': 'completed',
         'conditions': 'conditions',
         'jobid': 'jobid',
         'maximum_size': 'maximumSize',
@@ -48,12 +50,13 @@ class MiniClusterStatus(object):
         'size': 'size'
     }
 
-    def __init__(self, conditions=None, jobid='', maximum_size=0, selector='', size=0, local_vars_configuration=None):  # noqa: E501
+    def __init__(self, completed=False, conditions=None, jobid='', maximum_size=0, selector='', size=0, local_vars_configuration=None):  # noqa: E501
         """MiniClusterStatus - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
+        self._completed = None
         self._conditions = None
         self._jobid = None
         self._maximum_size = None
@@ -61,12 +64,38 @@ class MiniClusterStatus(object):
         self._size = None
         self.discriminator = None
 
+        self.completed = completed
         if conditions is not None:
             self.conditions = conditions
         self.jobid = jobid
         self.maximum_size = maximum_size
         self.selector = selector
         self.size = size
+
+    @property
+    def completed(self):
+        """Gets the completed of this MiniClusterStatus.  # noqa: E501
+
+        Label to indicate that job is completed, comes from Job.Completed The user can also look at conditions -> JobFinished  # noqa: E501
+
+        :return: The completed of this MiniClusterStatus.  # noqa: E501
+        :rtype: bool
+        """
+        return self._completed
+
+    @completed.setter
+    def completed(self, completed):
+        """Sets the completed of this MiniClusterStatus.
+
+        Label to indicate that job is completed, comes from Job.Completed The user can also look at conditions -> JobFinished  # noqa: E501
+
+        :param completed: The completed of this MiniClusterStatus.  # noqa: E501
+        :type completed: bool
+        """
+        if self.local_vars_configuration.client_side_validation and completed is None:  # noqa: E501
+            raise ValueError("Invalid value for `completed`, must not be `None`")  # noqa: E501
+
+        self._completed = completed
 
     @property
     def conditions(self):


### PR DESCRIPTION
we currently need a flag / status / label in argo to indicate that a minicluster is completed. We can derive this directly from the job, and pass forward the status to be used. I will test this with argo before merging