### PR TITLE
add pod affinity and antiffinity rules

### DIFF
--- a/controllers/flux/minicluster.go
+++ b/controllers/flux/minicluster.go
@@ -135,7 +135,7 @@ func (r *MiniClusterReconciler) ensureMiniCluster(
 		}
 
 		// Service name corresponds to container, but selector is pod-specific
-		selector := map[string]string{"app.kubernetes.io/name": cluster.Name}
+		selector := map[string]string{podLabelAppName: cluster.Name}
 		result, err = r.exposeService(ctx, cluster, container.Name, selector, container.Ports)
 		if err != nil {
 			return result, err

--- a/controllers/flux/pods.go
+++ b/controllers/flux/pods.go
@@ -23,6 +23,8 @@ import (
 	api "github.com/flux-framework/flux-operator/api/v1alpha1"
 )
 
+const podLabelAppName = "app.kubernetes.io/name"
+
 // Get labels for any pod in the cluster
 func getPodLabels(cluster *api.MiniCluster) map[string]string {
 	if cluster.Spec.Pod.Labels == nil {
@@ -30,7 +32,7 @@ func getPodLabels(cluster *api.MiniCluster) map[string]string {
 	}
 	podLabels := cluster.Spec.Pod.Labels
 	podLabels["namespace"] = cluster.Namespace
-	podLabels["app.kubernetes.io/name"] = cluster.Name
+	podLabels[podLabelAppName] = cluster.Name
 	return podLabels
 }
 


### PR DESCRIPTION
Add soft rules for the Job so Pods prefer to be scheduled on the same zone and not to be scheduled on the same node.

This will improve the performance as pods in the same node will still resources from each other, and pods in different zone will have a performance penalty since networking is most likely to be worse.