### PR TITLE
expose the index 0 pod for minimal service

### DIFF
--- a/controllers/flux/minicluster.go
+++ b/controllers/flux/minicluster.go
@@ -88,9 +88,10 @@ func (r *MiniClusterReconciler) ensureMiniCluster(
 	// Create headless service for the MiniCluster OR single service for the broker
 	selector := map[string]string{"job-name": cluster.Name}
 
-	// If we are adding a minimal service to the index 0 pod only
+	// If we are adding a minimal service expose the index 0 pod only
+	// LabelSelectors are ANDed
 	if cluster.Spec.Flux.MinimalService {
-		selector = map[string]string{"job-index": "0"}
+		selector["job-index"] = "0"
 	}
 
 	result, err = r.exposeServices(ctx, cluster, cluster.Spec.Network.HeadlessName, selector)


### PR DESCRIPTION
LabelSelectors multiple requirements are ANDed, however, the code was completely overriden the selector for the specific minicluster name, hence if there are multiple miniculster running in parallel the Service will expose all the indexed 0 pods from all the cluster.