### PR TITLE
podspec: add additional features for podspec

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.20 as builder
+FROM golang:1.20 AS builder
 
 WORKDIR /workspace
 

--- a/api/v1alpha2/minicluster_types.go
+++ b/api/v1alpha2/minicluster_types.go
@@ -188,6 +188,10 @@ type PodSpec struct {
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 
+	// RuntimeClassName for the pod
+	// +optional
+	RuntimeClassName string `json:"runtimeClassName,omitempty"`
+
 	// Automatically mount the service account name
 	// +optional
 	AutomountServiceAccountToken bool `json:"automountServiceAccountToken,omitempty"`

--- a/api/v1alpha2/swagger.json
+++ b/api/v1alpha2/swagger.json
@@ -775,6 +775,10 @@
           "description": "Restart Policy",
           "type": "string"
         },
+        "runtimeClassName": {
+          "description": "RuntimeClassName for the pod",
+          "type": "string"
+        },
         "schedulerName": {
           "description": "Scheduler name for the pod",
           "type": "string"

--- a/api/v1alpha2/zz_generated.openapi.go
+++ b/api/v1alpha2/zz_generated.openapi.go
@@ -1349,6 +1349,13 @@ func schema_flux_framework_flux_operator_api_v1alpha2_PodSpec(ref common.Referen
 							Format:      "",
 						},
 					},
+					"runtimeClassName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "RuntimeClassName for the pod",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"automountServiceAccountToken": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Automatically mount the service account name",

--- a/chart/templates/minicluster-crd.yaml
+++ b/chart/templates/minicluster-crd.yaml
@@ -555,6 +555,9 @@ spec:
                   restartPolicy:
                     description: Restart Policy
                     type: string
+                  runtimeClassName:
+                    description: RuntimeClassName for the pod
+                    type: string
                   schedulerName:
                     description: Scheduler name for the pod
                     type: string

--- a/config/crd/bases/flux-framework.org_miniclusters.yaml
+++ b/config/crd/bases/flux-framework.org_miniclusters.yaml
@@ -558,6 +558,9 @@ spec:
                   restartPolicy:
                     description: Restart Policy
                     type: string
+                  runtimeClassName:
+                    description: RuntimeClassName for the pod
+                    type: string
                   schedulerName:
                     description: Scheduler name for the pod
                     type: string

--- a/controllers/flux/job.go
+++ b/controllers/flux/job.go
@@ -69,6 +69,7 @@ func NewMiniClusterJob(cluster *api.MiniCluster) (*batchv1.Job, error) {
 					Volumes:                      getVolumes(cluster),
 					ImagePullSecrets:             getImagePullSecrets(cluster),
 					ServiceAccountName:           cluster.Spec.Pod.ServiceAccountName,
+					RuntimeClassName:             &cluster.Spec.Pod.RuntimeClassName,
 					AutomountServiceAccountToken: &cluster.Spec.Pod.AutomountServiceAccountToken,
 					RestartPolicy:                corev1.RestartPolicy(cluster.Spec.Pod.RestartPolicy),
 					NodeSelector:                 cluster.Spec.Pod.NodeSelector,

--- a/controllers/flux/job.go
+++ b/controllers/flux/job.go
@@ -70,12 +70,16 @@ func NewMiniClusterJob(cluster *api.MiniCluster) (*batchv1.Job, error) {
 					ImagePullSecrets:             getImagePullSecrets(cluster),
 					ServiceAccountName:           cluster.Spec.Pod.ServiceAccountName,
 					AutomountServiceAccountToken: &cluster.Spec.Pod.AutomountServiceAccountToken,
-					RestartPolicy:                corev1.RestartPolicy(cluster.Spec.Pod.RestartPolicy),
+					RestartPolicy:                corev1.RestartPolicyAlways,
 					NodeSelector:                 cluster.Spec.Pod.NodeSelector,
 					SchedulerName:                cluster.Spec.Pod.SchedulerName,
 				},
 			},
 		},
+	}
+	// Custom restart policy
+	if cluster.Spec.Pod.RestartPolicy != "" {
+		job.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicy(cluster.Spec.Pod.RestartPolicy)
 	}
 
 	// Only add runClassName if defined

--- a/controllers/flux/job.go
+++ b/controllers/flux/job.go
@@ -70,7 +70,7 @@ func NewMiniClusterJob(cluster *api.MiniCluster) (*batchv1.Job, error) {
 					ImagePullSecrets:             getImagePullSecrets(cluster),
 					ServiceAccountName:           cluster.Spec.Pod.ServiceAccountName,
 					AutomountServiceAccountToken: &cluster.Spec.Pod.AutomountServiceAccountToken,
-					RestartPolicy:                corev1.RestartPolicyAlways,
+					RestartPolicy:                corev1.RestartPolicyOnFailure,
 					NodeSelector:                 cluster.Spec.Pod.NodeSelector,
 					SchedulerName:                cluster.Spec.Pod.SchedulerName,
 				},

--- a/controllers/flux/pods.go
+++ b/controllers/flux/pods.go
@@ -137,6 +137,7 @@ func (r *MiniClusterReconciler) newServicePod(
 			ImagePullSecrets:             getImagePullSecrets(cluster),
 			RestartPolicy:                corev1.RestartPolicy(cluster.Spec.Pod.RestartPolicy),
 			ServiceAccountName:           cluster.Spec.Pod.ServiceAccountName,
+			RuntimeClassName:             &cluster.Spec.Pod.RuntimeClassName,
 			AutomountServiceAccountToken: &cluster.Spec.Pod.AutomountServiceAccountToken,
 			NodeSelector:                 cluster.Spec.Pod.NodeSelector,
 		},

--- a/controllers/flux/pods.go
+++ b/controllers/flux/pods.go
@@ -135,11 +135,16 @@ func (r *MiniClusterReconciler) newServicePod(
 			SetHostnameAsFQDN:            &setAsFQDN,
 			Volumes:                      existingVolumes,
 			ImagePullSecrets:             getImagePullSecrets(cluster),
-			RestartPolicy:                corev1.RestartPolicy(cluster.Spec.Pod.RestartPolicy),
+			RestartPolicy:                corev1.RestartPolicyAlways,
 			ServiceAccountName:           cluster.Spec.Pod.ServiceAccountName,
 			AutomountServiceAccountToken: &cluster.Spec.Pod.AutomountServiceAccountToken,
 			NodeSelector:                 cluster.Spec.Pod.NodeSelector,
 		},
+	}
+
+	// Custom restart policy
+	if cluster.Spec.Pod.RestartPolicy != "" {
+		pod.Spec.RestartPolicy = corev1.RestartPolicy(cluster.Spec.Pod.RestartPolicy)
 	}
 
 	// Only add runClassName if defined

--- a/controllers/flux/pods.go
+++ b/controllers/flux/pods.go
@@ -137,10 +137,14 @@ func (r *MiniClusterReconciler) newServicePod(
 			ImagePullSecrets:             getImagePullSecrets(cluster),
 			RestartPolicy:                corev1.RestartPolicy(cluster.Spec.Pod.RestartPolicy),
 			ServiceAccountName:           cluster.Spec.Pod.ServiceAccountName,
-			RuntimeClassName:             &cluster.Spec.Pod.RuntimeClassName,
 			AutomountServiceAccountToken: &cluster.Spec.Pod.AutomountServiceAccountToken,
 			NodeSelector:                 cluster.Spec.Pod.NodeSelector,
 		},
+	}
+
+	// Only add runClassName if defined
+	if cluster.Spec.Pod.RuntimeClassName != "" {
+		pod.Spec.RuntimeClassName = &cluster.Spec.Pod.RuntimeClassName
 	}
 
 	// Assemble existing volume mounts - they are added with getContainers

--- a/controllers/flux/pods.go
+++ b/controllers/flux/pods.go
@@ -135,7 +135,7 @@ func (r *MiniClusterReconciler) newServicePod(
 			SetHostnameAsFQDN:            &setAsFQDN,
 			Volumes:                      existingVolumes,
 			ImagePullSecrets:             getImagePullSecrets(cluster),
-			RestartPolicy:                corev1.RestartPolicyAlways,
+			RestartPolicy:                corev1.RestartPolicyOnFailure,
 			ServiceAccountName:           cluster.Spec.Pod.ServiceAccountName,
 			AutomountServiceAccountToken: &cluster.Spec.Pod.AutomountServiceAccountToken,
 			NodeSelector:                 cluster.Spec.Pod.NodeSelector,

--- a/docs/getting_started/custom-resource-definition.md
+++ b/docs/getting_started/custom-resource-definition.md
@@ -188,7 +188,10 @@ When enabled, meaning that we use flux from a view within the container, these c
 
  - [ghcr.io/converged-computing/flux-view-rocky:tag-9](https://github.com/converged-computing/flux-views/pkgs/container/flux-view-rocky)
  - [ghcr.io/converged-computing/flux-view-rocky:tag-8](https://github.com/converged-computing/flux-views/pkgs/container/flux-view-rocky)
+ - [ghcr.io/converged-computing/flux-view-ubuntu:tag-noble](https://github.com/converged-computing/flux-views/pkgs/container/flux-view-ubuntu)
+ - [ghcr.io/converged-computing/flux-view-ubuntu:tag-jammy](https://github.com/converged-computing/flux-views/pkgs/container/flux-view-ubuntu)
  - [ghcr.io/converged-computing/flux-view-ubuntu:tag-focal](https://github.com/converged-computing/flux-views/pkgs/container/flux-view-ubuntu)
+
 
 Note that we have [arm builds](https://github.com/converged-computing/flux-views/tree/main/arm) available for each of rocky and ubuntu as well.
 If you don't want to use Flux from a view (and want to use the v1apha1 design of the Flux Operator that had the application alongside Flux) you can do that by way of disabling the flux view:
@@ -682,6 +685,34 @@ pod:
   serviceAccountName: my-service-account
 ```
 
+#### restartPolicy
+
+To customize the restartPolicy for the pod:
+
+```yaml
+pod:
+  restartPolicy: Never
+```
+
+#### runtimeClassName
+
+To add a runtime class name:
+
+```yaml
+pod:
+  runtimeClassName: nvidia
+```
+
+#### automountServiceAccountToken
+
+If you want to automatically mount a service account token:
+
+```yaml
+pod:
+  automountServiceAccountToken: true
+```
+
+
 #### nodeSelector
 
 A node selector is a set of key value pairs that helps to schedule pods to the right nodes! You can
@@ -720,10 +751,8 @@ name: rabbit
 
 #### image
 
-This is the only required attribute! You *must* provide a container base that has Flux.
-The requirements of your container are defined in the README of the [flux-hpc](https://github.com/rse-ops/flux-hpc/)
-repository. Generally speaking, you need to have Flux executables, Flux Python bindings,
-and your own executables on the path, and should be started with root with a flux user.
+You do not need to provide a container base that has Flux, but you must make sure your view (with a particular operator system) that will add Flux matches your container. We don't require you to start as root, but if you
+have a container with a non-root user, the user needs to have sudo available (to act as root).
 If you use the [fluxrm/flux-sched](https://hub.docker.com/r/fluxrm/flux-sched)
 base containers this is usually a good start.
 

--- a/examples/dist/flux-operator-arm.yaml
+++ b/examples/dist/flux-operator-arm.yaml
@@ -564,6 +564,9 @@ spec:
                   restartPolicy:
                     description: Restart Policy
                     type: string
+                  runtimeClassName:
+                    description: RuntimeClassName for the pod
+                    type: string
                   schedulerName:
                     description: Scheduler name for the pod
                     type: string

--- a/examples/dist/flux-operator.yaml
+++ b/examples/dist/flux-operator.yaml
@@ -564,6 +564,9 @@ spec:
                   restartPolicy:
                     description: Restart Policy
                     type: string
+                  runtimeClassName:
+                    description: RuntimeClassName for the pod
+                    type: string
                   schedulerName:
                     description: Scheduler name for the pod
                     type: string

--- a/sdk/python/v1alpha2/docs/PodSpec.md
+++ b/sdk/python/v1alpha2/docs/PodSpec.md
@@ -11,6 +11,7 @@ Name | Type | Description | Notes
 **node_selector** | **dict[str, str]** | NodeSelectors for a pod | [optional] 
 **resources** | [**dict[str, IntOrString]**](IntOrString.md) | Resources include limits and requests | [optional] 
 **restart_policy** | **str** | Restart Policy | [optional] 
+**runtime_class_name** | **str** | RuntimeClassName for the pod | [optional] 
 **scheduler_name** | **str** | Scheduler name for the pod | [optional] 
 **service_account_name** | **str** | Service account name for the pod | [optional] 
 

--- a/sdk/python/v1alpha2/fluxoperator/models/pod_spec.py
+++ b/sdk/python/v1alpha2/fluxoperator/models/pod_spec.py
@@ -42,6 +42,7 @@ class PodSpec(object):
         'node_selector': 'dict[str, str]',
         'resources': 'dict[str, IntOrString]',
         'restart_policy': 'str',
+        'runtime_class_name': 'str',
         'scheduler_name': 'str',
         'service_account_name': 'str'
     }
@@ -53,11 +54,12 @@ class PodSpec(object):
         'node_selector': 'nodeSelector',
         'resources': 'resources',
         'restart_policy': 'restartPolicy',
+        'runtime_class_name': 'runtimeClassName',
         'scheduler_name': 'schedulerName',
         'service_account_name': 'serviceAccountName'
     }
 
-    def __init__(self, annotations=None, automount_service_account_token=None, labels=None, node_selector=None, resources=None, restart_policy=None, scheduler_name=None, service_account_name=None, local_vars_configuration=None):  # noqa: E501
+    def __init__(self, annotations=None, automount_service_account_token=None, labels=None, node_selector=None, resources=None, restart_policy=None, runtime_class_name=None, scheduler_name=None, service_account_name=None, local_vars_configuration=None):  # noqa: E501
         """PodSpec - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration.get_default_copy()
@@ -69,6 +71,7 @@ class PodSpec(object):
         self._node_selector = None
         self._resources = None
         self._restart_policy = None
+        self._runtime_class_name = None
         self._scheduler_name = None
         self._service_account_name = None
         self.discriminator = None
@@ -85,6 +88,8 @@ class PodSpec(object):
             self.resources = resources
         if restart_policy is not None:
             self.restart_policy = restart_policy
+        if runtime_class_name is not None:
+            self.runtime_class_name = runtime_class_name
         if scheduler_name is not None:
             self.scheduler_name = scheduler_name
         if service_account_name is not None:
@@ -227,6 +232,29 @@ class PodSpec(object):
         """
 
         self._restart_policy = restart_policy
+
+    @property
+    def runtime_class_name(self):
+        """Gets the runtime_class_name of this PodSpec.  # noqa: E501
+
+        RuntimeClassName for the pod  # noqa: E501
+
+        :return: The runtime_class_name of this PodSpec.  # noqa: E501
+        :rtype: str
+        """
+        return self._runtime_class_name
+
+    @runtime_class_name.setter
+    def runtime_class_name(self, runtime_class_name):
+        """Sets the runtime_class_name of this PodSpec.
+
+        RuntimeClassName for the pod  # noqa: E501
+
+        :param runtime_class_name: The runtime_class_name of this PodSpec.  # noqa: E501
+        :type runtime_class_name: str
+        """
+
+        self._runtime_class_name = runtime_class_name
 
     @property
     def scheduler_name(self):


### PR DESCRIPTION
runtimeClassName can be used to designate nvidia for skypilot.

It looks like we also need:

- an ability to designate specific labels for the leader (index 0) vs the workers. (doesn't seem hugely important)
- the running user must be sky (we have root) and thus the container needs sudo