### PR TITLE
fluxion: add support to easily load

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.20 AS builder
+FROM golang:1.22 AS builder
 
 WORKDIR /workspace
 

--- a/api/v1alpha2/minicluster_types.go
+++ b/api/v1alpha2/minicluster_types.go
@@ -367,6 +367,10 @@ type FluxSpec struct {
 // FluxScheduler attributes
 type FluxScheduler struct {
 
+	// Use sched-simple (no support for GPU)
+	// +optional
+	Simple bool `json:"simple"`
+
 	// Scheduler queue policy, defaults to "fcfs" can also be "easy"
 	// +optional
 	QueuePolicy string `json:"queuePolicy"`

--- a/api/v1alpha2/swagger.json
+++ b/api/v1alpha2/swagger.json
@@ -250,6 +250,11 @@
           "description": "Scheduler queue policy, defaults to \"fcfs\" can also be \"easy\"",
           "type": "string",
           "default": ""
+        },
+        "simple": {
+          "description": "Use sched-simple (no support for GPU)",
+          "type": "boolean",
+          "default": false
         }
       }
     },

--- a/api/v1alpha2/zz_generated.openapi.go
+++ b/api/v1alpha2/zz_generated.openapi.go
@@ -469,6 +469,14 @@ func schema_flux_framework_flux_operator_api_v1alpha2_FluxScheduler(ref common.R
 				Description: "FluxScheduler attributes",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"simple": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Use sched-simple (no support for GPU)",
+							Default:     false,
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"queuePolicy": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Scheduler queue policy, defaults to \"fcfs\" can also be \"easy\"",

--- a/chart/templates/minicluster-crd.yaml
+++ b/chart/templates/minicluster-crd.yaml
@@ -460,6 +460,9 @@ spec:
                         description: Scheduler queue policy, defaults to "fcfs" can
                           also be "easy"
                         type: string
+                      simple:
+                        description: Use sched-simple (no support for GPU)
+                        type: boolean
                     type: object
                   submitCommand:
                     description: Modify flux submit to be something else

--- a/config/crd/bases/flux-framework.org_miniclusters.yaml
+++ b/config/crd/bases/flux-framework.org_miniclusters.yaml
@@ -461,6 +461,9 @@ spec:
                         description: Scheduler queue policy, defaults to "fcfs" can
                           also be "easy"
                         type: string
+                      simple:
+                        description: Use sched-simple (no support for GPU)
+                        type: boolean
                     type: object
                   submitCommand:
                     description: Modify flux submit to be something else

--- a/docs/getting_started/custom-resource-definition.md
+++ b/docs/getting_started/custom-resource-definition.md
@@ -351,6 +351,39 @@ And the broker.toml config will update appropriately:
 queue-policy = "easy"
 ```
 
+By default, we use the simple sched algorithm. To load fluxion, you can connect to the lead broker and load the correct modules.
+
+```bash
+kubectl exec -it flux-sample-0-7mqg5 bash
+. /mnt/flux/flux-view.sh 
+flux proxy $fluxsocket bash
+bash /mnt/flux/load-fluxion.sh 
+```
+
+Verify it is loaded - you should see two modules for fluxion, qmanager and resource.
+
+```bash
+$ flux module list
+Module                   Idle  S Service
+job-info                   21  R 
+sched-fluxion-qmanager      5  R sched
+sched-fluxion-resource      5  R 
+job-exec                   21  R 
+connector-local             0  R 
+kvs-watch                  21  R 
+heartbeat                   1  R 
+content                    20  R 
+kvs                        20  R 
+content-sqlite             20  R content-backing
+job-list                   21  R 
+job-ingest                 20  R 
+job-archive                21  R 
+resource                    5  R 
+barrier                    21  R 
+job-manager                 5  R 
+cron                       21  R 
+```
+
 You can learn more about queues [here](https://flux-framework.readthedocs.io/en/latest/guides/admin-guide.html?h=system#adding-queues). Please [open an issue](https://github.com/flux-framework/flux-operator/issues) if you want support for something that you don't see. Also note that you can set an entire [broker config](#broker-config) for more detailed customization.
 
 #### minimalService

--- a/examples/dist/flux-operator-arm.yaml
+++ b/examples/dist/flux-operator-arm.yaml
@@ -467,6 +467,9 @@ spec:
                         description: Scheduler queue policy, defaults to "fcfs" can
                           also be "easy"
                         type: string
+                      simple:
+                        description: Use sched-simple (no support for GPU)
+                        type: boolean
                     type: object
                   submitCommand:
                     description: Modify flux submit to be something else

--- a/examples/dist/flux-operator.yaml
+++ b/examples/dist/flux-operator.yaml
@@ -467,6 +467,9 @@ spec:
                         description: Scheduler queue policy, defaults to "fcfs" can
                           also be "easy"
                         type: string
+                      simple:
+                        description: Use sched-simple (no support for GPU)
+                        type: boolean
                     type: object
                   submitCommand:
                     description: Modify flux submit to be something else

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/flux-framework/flux-operator
 
-go 1.20
+go 1.22
 
 require (
 	github.com/go-logr/logr v1.2.3

--- a/go.sum
+++ b/go.sum
@@ -396,6 +396,7 @@ github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9k
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/ginkgo/v2 v2.1.4 h1:GNapqRSid3zijZ9H77KrgVG4/8KqiyRsxcSxe+7ApXY=
+github.com/onsi/ginkgo/v2 v2.1.4/go.mod h1:um6tUpWM/cxCK3/FK8BXqEiUMUwRgSM4JXG47RKZmLU=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
@@ -527,6 +528,7 @@ go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/goleak v1.1.11-0.20210813005559-691160354723/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/goleak v1.1.12 h1:gZAh5/EyT/HQwlpkCy6wTpqfH9H8Lz8zbm3dZh+OyzA=
+go.uber.org/goleak v1.1.12/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.6.0 h1:y6IPFStTAIT5Ytl7/XYmHvzXQ7S3g/IeZW9hyZ5thw4=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=

--- a/pkg/flux/templates/components.sh
+++ b/pkg/flux/templates/components.sh
@@ -85,6 +85,15 @@ echo "PATH is $PATH" {{ if .Spec.Logging.Quiet }}> /dev/null 2>&1{{ end }}
 
 find $viewroot . -name libpython*.so* {{ if .Spec.Logging.Quiet }}> /dev/null 2>&1{{ end }}
 ls -l /mnt/flux/view/lib/libpython3.11.so.1.0 {{ if .Spec.Logging.Quiet }}> /dev/null 2>&1{{ end }}
+{{ if .Spec.Flux.Scheduler.Simple }}{{ else }}export FLUX_RC_EXTRA=$viewroot/etc/flux/rc1.d{{ end }}
+
+# Write a script to load fluxion
+cat <<EOT >> ./load-fluxion.sh
+flux module remove sched-simple
+flux module load sched-fluxion-resource
+flux module load sched-fluxion-qmanager
+EOT
+${SUDO} mv ./load-fluxion.sh ${viewbase}/load-fluxion.sh
 
 # Write an easy file we can source for the environment
 cat <<EOT >> ./flux-view.sh

--- a/sdk/python/v1alpha2/docs/FluxScheduler.md
+++ b/sdk/python/v1alpha2/docs/FluxScheduler.md
@@ -7,6 +7,7 @@ FluxScheduler attributes
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **queue_policy** | **str** | Scheduler queue policy, defaults to \&quot;fcfs\&quot; can also be \&quot;easy\&quot; | [optional] [default to '']
+**simple** | **bool** | Use sched-simple (no support for GPU) | [optional] [default to False]
 
 ## Example
 

--- a/sdk/python/v1alpha2/fluxoperator/models/flux_scheduler.py
+++ b/sdk/python/v1alpha2/fluxoperator/models/flux_scheduler.py
@@ -17,7 +17,7 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, Field, StrictStr
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
 from typing import Optional, Set
 from typing_extensions import Self
@@ -27,7 +27,8 @@ class FluxScheduler(BaseModel):
     FluxScheduler attributes
     """ # noqa: E501
     queue_policy: Optional[StrictStr] = Field(default='', description="Scheduler queue policy, defaults to \"fcfs\" can also be \"easy\"", alias="queuePolicy")
-    __properties: ClassVar[List[str]] = ["queuePolicy"]
+    simple: Optional[StrictBool] = Field(default=False, description="Use sched-simple (no support for GPU)")
+    __properties: ClassVar[List[str]] = ["queuePolicy", "simple"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -80,7 +81,8 @@ class FluxScheduler(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
-            "queuePolicy": obj.get("queuePolicy") if obj.get("queuePolicy") is not None else ''
+            "queuePolicy": obj.get("queuePolicy") if obj.get("queuePolicy") is not None else '',
+            "simple": obj.get("simple") if obj.get("simple") is not None else False
         })
         return _obj
 


### PR DESCRIPTION
We do not spack load so fluxion does not show up
as the default. As a quick fix we can provide a script to unload sched-simple and load sched-fluxion-*