### PR TITLE
bug: race condition for service name

### DIFF
--- a/api/v1alpha2/minicluster_types.go
+++ b/api/v1alpha2/minicluster_types.go
@@ -114,8 +114,6 @@ type MiniClusterSpec struct {
 type Network struct {
 
 	// Name for cluster headless service
-	// +kubebuilder:default="flux-service"
-	// +default="flux-service"
 	// +optional
 	HeadlessName string `json:"headlessName,omitempty"`
 
@@ -825,7 +823,7 @@ func (f *MiniCluster) Validate() bool {
 
 	// Set the default headless service name
 	if f.Spec.Network.HeadlessName == "" {
-		f.Spec.Network.HeadlessName = "flux-service"
+		f.Spec.Network.HeadlessName = f.Name
 	}
 	if f.Spec.Flux.Container.Name == "" {
 		f.Spec.Flux.Container.Name = "flux-view"

--- a/chart/templates/minicluster-crd.yaml
+++ b/chart/templates/minicluster-crd.yaml
@@ -568,7 +568,6 @@ spec:
                       / node
                     type: boolean
                   headlessName:
-                    default: flux-service
                     description: Name for cluster headless service
                     type: string
                 type: object

--- a/config/crd/bases/flux-framework.org_miniclusters.yaml
+++ b/config/crd/bases/flux-framework.org_miniclusters.yaml
@@ -571,7 +571,6 @@ spec:
                       address / node
                     type: boolean
                   headlessName:
-                    default: flux-service
                     description: Name for cluster headless service
                     type: string
                 type: object

--- a/examples/dist/flux-operator-arm.yaml
+++ b/examples/dist/flux-operator-arm.yaml
@@ -577,7 +577,6 @@ spec:
                       address / node
                     type: boolean
                   headlessName:
-                    default: flux-service
                     description: Name for cluster headless service
                     type: string
                 type: object

--- a/examples/dist/flux-operator.yaml
+++ b/examples/dist/flux-operator.yaml
@@ -577,7 +577,6 @@ spec:
                       address / node
                     type: boolean
                   headlessName:
-                    default: flux-service
                     description: Name for cluster headless service
                     type: string
                 type: object


### PR DESCRIPTION
A service name (defaulting to flux-service) that is shared by two MiniClusters can lead to a race condition, where one cluster is cleaning up (but the service still exists, associated with the deleting job) and then the new cluster coming up looks for it (and finds it) and does not recreate. In practice the network will fail to bootstrap. I believe we have seen this issue on the rabbit nodes, and I just saw it in scaling experiments. This change will test if the issue is resolved.